### PR TITLE
quick POC at non-Long numerics (encoding and decoding)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ In case you don't have much time for this - at least spend 5 seconds to give us 
 
 ## Acknowledgement
 Special thanks to those awesome developers who give us great suggestions, help us to maintain and improve this project:
-@NightEule5, @bishiboosh, @Peanuuutz, @petertrr, @nulls, @Olivki, @edrd-f and @BOOMeranGG.
+@NightEule5, @bishiboosh, @Peanuuutz, @petertrr, @nulls, @Olivki, @edrd-f, @BOOMeranGG, @aSemy
 
 ## Supported platforms
 All the code is written in Kotlin **common** module. This means that it can be built for each and every Kotlin native platform.
@@ -68,7 +68,8 @@ We are still developing and testing this library, so it has several limitations:
 :white_check_mark: Offset Date-Time (to `Instant` of [kotlinx-datetime](https://github.com/Kotlin/kotlinx-datetime)) \
 :white_check_mark: Local Date-Time (to `LocalDateTime` of [kotlinx-datetime](https://github.com/Kotlin/kotlinx-datetime)) \
 :white_check_mark: Local Date (to `LocalDate` of [kotlinx-datetime](https://github.com/Kotlin/kotlinx-datetime)) \
-:x: Arrays: nested; multiline; of Different Types \
+:white_check_mark: Arrays (including multiline arrays) \
+:x: Arrays: nested; of Different Types \
 :x: Multiline Strings \
 :x: Nested Inline Tables \
 :x: Array of Tables \

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/decoders/TomlAbstractDecoder.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/decoders/TomlAbstractDecoder.kt
@@ -26,8 +26,8 @@ public abstract class TomlAbstractDecoder : AbstractDecoder() {
     override fun decodeByte(): Byte = decodePrimitiveType()
     override fun decodeShort(): Short = decodePrimitiveType()
     override fun decodeInt(): Int = decodePrimitiveType()
-    override fun decodeFloat(): Float = decodePrimitiveType()
-    override fun decodeChar(): Char = decodePrimitiveType()
+    override fun decodeFloat(): Float = invalidType("Float", "Double")
+    override fun decodeChar(): Char = invalidType("Char", "String")
 
     // Valid Toml types that should be properly decoded
     override fun decodeBoolean(): Boolean = decodePrimitiveType()
@@ -86,6 +86,11 @@ public abstract class TomlAbstractDecoder : AbstractDecoder() {
         Short::class -> validateAndConvertInt(content, lineNo, SHORT) { num: Long -> num.toShort() as T }
         Int::class -> validateAndConvertInt(content, lineNo, INT) { num: Long -> num.toInt() as T }
         Long::class -> validateAndConvertInt(content, lineNo, LONG) { num: Long -> num as T }
+        Double::class, Float::class -> throw IllegalTypeException(
+            "Expected floating-point number, but received integer literal: <$content>. " +
+                    "Deserialized floating-point number should have a dot: <$content.0>",
+            lineNo
+        )
         else -> invalidType(T::class.toString(), "Signed Type")
     }
 

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/encoders/TomlAbstractEncoder.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/encoders/TomlAbstractEncoder.kt
@@ -154,24 +154,11 @@ public abstract class TomlAbstractEncoder protected constructor(
         }
     }
 
-    override fun encodeByte(value: Byte): Nothing = invalidType("Byte", "Long", value)
-    override fun encodeShort(value: Short): Nothing = invalidType("Short", "Long", value)
-    override fun encodeInt(value: Int): Nothing = invalidType("Int", "Long", value)
-    override fun encodeFloat(value: Float): Nothing = invalidType("Float", "Double", value)
-    override fun encodeChar(value: Char): Nothing = invalidType("Char", "String", value)
-
-    // Todo: Do we really want to make these invalid?
-    private fun invalidType(
-        typeName: String,
-        requiredType: String,
-        value: Any
-    ): Nothing {
-        throw IllegalEncodingTypeException(
-            "<$typeName> is not allowed by the TOML specification, use <$requiredType>" +
-                    " instead (key = ${attributes.getFullKey()}; value = $value)",
-            elementIndex
-        )
-    }
+    override fun encodeByte(value: Byte): Unit = encodeLong(value.toLong())
+    override fun encodeShort(value: Short): Unit = encodeLong(value.toLong())
+    override fun encodeInt(value: Int): Unit = encodeLong(value.toLong())
+    override fun encodeFloat(value: Float): Unit = encodeDouble(value.toDouble())
+    override fun encodeChar(value: Char): Unit = encodeString(value.toString())
 
     // Structure
 

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/encoders/TomlAbstractEncoder.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/encoders/TomlAbstractEncoder.kt
@@ -2,7 +2,6 @@ package com.akuleshov7.ktoml.encoders
 
 import com.akuleshov7.ktoml.TomlInputConfig
 import com.akuleshov7.ktoml.TomlOutputConfig
-import com.akuleshov7.ktoml.exceptions.IllegalEncodingTypeException
 import com.akuleshov7.ktoml.exceptions.InternalEncodingException
 import com.akuleshov7.ktoml.exceptions.UnsupportedEncodingFeatureException
 import com.akuleshov7.ktoml.tree.nodes.TomlNode

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/GeneralDecoderTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/GeneralDecoderTest.kt
@@ -125,10 +125,12 @@ class GeneralDecoderTest {
 
     @Test
     fun testForSimpleNestedTable() {
-        val test = ("c = 5 \n" +
-                "[table1] \n" +
-                " b = 6  \n" +
-                " a = 5  \n ")
+        val test = """
+            c = 5 
+            [table1] 
+            b = 6  
+            a = 5  
+        """.trimIndent()
         assertEquals(NestedSimpleTable(5, Table1(5, 6)), Toml.decodeFromString(test))
     }
 
@@ -374,19 +376,20 @@ class GeneralDecoderTest {
 
     @Test
     fun severalTablesOnTheSameLevel() {
-        val test = """|[table]
-           |[table.in1]
-           |    a = 1
-           |    [table.in1.in1]
-           |        a = 1
-           |    [table.in1.in2]
-           |        a = 1
-           |[table.in2]
-           |    a = 1
-           |    [table.in2.in1]
-           |        a = 1
-           |    [table.in2.in2]
-           |        a = 1
+        val test = """
+            |[table]
+            |[table.in1]
+            |    a = 1
+            |    [table.in1.in1]
+            |        a = 1
+            |    [table.in1.in2]
+            |        a = 1
+            |[table.in2]
+            |    a = 1
+            |    [table.in2.in1]
+            |        a = 1
+            |    [table.in2.in2]
+            |        a = 1
         """.trimMargin()
 
         assertEquals(

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/PrimitivesDecoderTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/PrimitivesDecoderTest.kt
@@ -1,23 +1,25 @@
 package com.akuleshov7.ktoml.decoders
 
 import com.akuleshov7.ktoml.Toml
+import com.akuleshov7.ktoml.exceptions.IllegalTypeException
 import com.akuleshov7.ktoml.exceptions.ParseException
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
-class PrimitivesDecoderTest {
 
+class PrimitivesDecoderTest {
     @Test
     fun decodeByte() {
-        fun test(expected: Byte, actual: String) {
-            val toml = /*language=TOML*/ """value = $actual"""
+        fun test(expected: Byte, input: String) {
+            val toml = /*language=TOML*/ """value = $input"""
 
             @Serializable
             data class Data(val value: Byte)
 
-            val data = Toml.decodeFromString(Data.serializer(), toml)
+            val data = Toml.decodeFromString<Data>(toml)
 
             assertEquals(expected, data.value)
         }
@@ -37,8 +39,8 @@ class PrimitivesDecoderTest {
             @Serializable
             data class Data(val value: Byte)
 
-            assertFailsWith<ParseException>(input) {
-                Toml.decodeFromString(Data.serializer(), toml)
+            assertFailsWith<IllegalTypeException>(input) {
+                Toml.decodeFromString<Data>(toml)
             }
         }
 
@@ -48,15 +50,16 @@ class PrimitivesDecoderTest {
 
     @Test
     fun decodeChar() {
-        fun test(expected: Char, actual: String) {
-            val toml = /*language=TOML*/ """value = $actual"""
+        fun test(expected: Char, input: String) {
+            val toml = /*language=TOML*/ """value = $input"""
 
             @Serializable
             data class Data(val value: Char)
 
-            val data = Toml.decodeFromString(Data.serializer(), toml)
-
-            assertEquals(expected, data.value)
+            assertFailsWith<IllegalTypeException> {
+                val data = Toml.decodeFromString<Data>(toml)
+                assertEquals(expected, data.value)
+            }
         }
 
         test((0).toChar(), "0")
@@ -67,31 +70,14 @@ class PrimitivesDecoderTest {
     }
 
     @Test
-    fun decodeCharFailure() {
-        fun testFails(input: String) {
-            val toml = /*language=TOML*/ """value = $input"""
-
-            @Serializable
-            data class Data(val value: Byte)
-
-            assertFailsWith<ParseException>(input) {
-                Toml.decodeFromString(Data.serializer(), toml)
-            }
-        }
-
-        testFails("${Char.MAX_VALUE.digitToInt() + 1}")
-        testFails("${Char.MIN_VALUE.digitToInt() - 1}")
-    }
-
-    @Test
     fun decodeShort() {
-        fun test(expected: Short, actual: String) {
-            val toml = /*language=TOML*/ """value = $actual"""
+        fun test(expected: Short, input: String) {
+            val toml = /*language=TOML*/ """value = $input"""
 
             @Serializable
             data class Data(val value: Short)
 
-            val data = Toml.decodeFromString(Data.serializer(), toml)
+            val data = Toml.decodeFromString<Data>(toml)
 
             assertEquals(expected, data.value)
         }
@@ -111,8 +97,8 @@ class PrimitivesDecoderTest {
             @Serializable
             data class Data(val value: Short)
 
-            assertFailsWith<ParseException>(input) {
-                Toml.decodeFromString(Data.serializer(), toml)
+            assertFailsWith<IllegalTypeException>(input) {
+                Toml.decodeFromString<Data>(toml)
             }
         }
 
@@ -122,13 +108,13 @@ class PrimitivesDecoderTest {
 
     @Test
     fun decodeInt() {
-        fun test(expected: Int, actual: String) {
-            val toml = /*language=TOML*/ """value = $actual"""
+        fun test(expected: Int, input: String) {
+            val toml = /*language=TOML*/ """value = $input"""
 
             @Serializable
             data class Data(val value: Int)
 
-            val data = Toml.decodeFromString(Data.serializer(), toml)
+            val data = Toml.decodeFromString<Data>(toml)
 
             assertEquals(expected, data.value)
         }
@@ -150,8 +136,8 @@ class PrimitivesDecoderTest {
             @Serializable
             data class Data(val value: Int)
 
-            assertFailsWith<ParseException>(input) {
-                Toml.decodeFromString(Data.serializer(), toml)
+            assertFailsWith<IllegalTypeException>(input) {
+                Toml.decodeFromString<Data>(toml)
             }
         }
 
@@ -161,13 +147,13 @@ class PrimitivesDecoderTest {
 
     @Test
     fun decodeLong() {
-        fun test(expected: Long, actual: String) {
-            val toml = /*language=TOML*/ """value = $actual"""
+        fun test(expected: Long, input: String) {
+            val toml = /*language=TOML*/ """value = $input"""
 
             @Serializable
             data class Data(val value: Long)
 
-            val data = Toml.decodeFromString(Data.serializer(), toml)
+            val data = Toml.decodeFromString<Data>(toml)
 
             assertEquals(expected, data.value)
         }
@@ -189,8 +175,8 @@ class PrimitivesDecoderTest {
             @Serializable
             data class Data(val value: Long)
 
-            assertFailsWith<ParseException>(input) {
-                Toml.decodeFromString(Data.serializer(), toml)
+            assertFailsWith<IllegalTypeException>(input) {
+                Toml.decodeFromString<Data>(toml)
             }
         }
 
@@ -200,15 +186,16 @@ class PrimitivesDecoderTest {
 
     @Test
     fun decodeFloat() {
-        fun test(expected: Float, actual: String) {
-            val toml = /*language=TOML*/ """value = $actual"""
+        fun test(expected: Float, input: String) {
+            val toml = /*language=TOML*/ """value = $input"""
 
             @Serializable
             data class Data(val value: Float)
 
-            val data = Toml.decodeFromString(Data.serializer(), toml)
-
-            assertEquals(expected, data.value)
+            assertFailsWith<IllegalTypeException> {
+                val data = Toml.decodeFromString<Data>(toml)
+                assertEquals(expected, data.value)
+            }
         }
 
         test(0f, "0")
@@ -226,8 +213,8 @@ class PrimitivesDecoderTest {
             @Serializable
             data class Data(val value: Float)
 
-            assertFailsWith<ParseException>(input) {
-                Toml.decodeFromString(Data.serializer(), toml)
+            assertFailsWith<IllegalTypeException>(input) {
+                Toml.decodeFromString<Data>(toml)
             }
         }
 
@@ -237,22 +224,22 @@ class PrimitivesDecoderTest {
 
     @Test
     fun decodeDouble() {
-        fun test(expected: Double, actual: String) {
-            val toml = /*language=TOML*/ """value = $actual"""
+        fun test(expected: Double, input: String) {
+            val toml = /*language=TOML*/ """value = $input"""
 
             @Serializable
             data class Data(val value: Double)
 
-            val data = Toml.decodeFromString(Data.serializer(), toml)
+            val data = Toml.decodeFromString<Data>(toml)
 
             assertEquals(expected, data.value)
         }
 
-        test(0.0, "0")
-        test(1.0, "1")
-        test(-1.0, "-1")
-        test(-128.0, "-128")
-        test(127.0, "127")
+        test(0.0, "0.0")
+        test(1.0, "1.0")
+        test(-1.0, "-1.0")
+        test(-128.0, "-128.0")
+        test(127.0, "127.0")
     }
 
     @Test
@@ -263,12 +250,13 @@ class PrimitivesDecoderTest {
             @Serializable
             data class Data(val value: Double)
 
-            assertFailsWith<ParseException>(input) {
-                Toml.decodeFromString(Data.serializer(), toml)
+            assertFailsWith<IllegalTypeException>(input) {
+                Toml.decodeFromString<Data>(toml)
             }
         }
 
         testFails("-129")
         testFails("128")
+        testFails("0")
     }
 }

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/PrimitivesDecoderTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/PrimitivesDecoderTest.kt
@@ -1,0 +1,146 @@
+package com.akuleshov7.ktoml.decoders
+
+import com.akuleshov7.ktoml.Toml
+import com.akuleshov7.ktoml.exceptions.ParseException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.serialization.Serializable
+
+class PrimitivesDecoderTest {
+
+  @Test
+  fun decodeByte() {
+    fun test(expected: Byte, actual: String) {
+      val toml = /*language=TOML*/ """value = $actual"""
+
+      @Serializable
+      data class Data(val value: Byte)
+
+      val data = Toml.decodeFromString(Data.serializer(), toml)
+
+      assertEquals(expected, data.value)
+    }
+
+    test(0, "0")
+    test(1, "1")
+    test(-1, "-1")
+    test(-128, "-128")
+    test(127, "127")
+  }
+
+  @Test
+  fun decodeByteFailure() {
+    fun testFails(input: String) {
+      val toml = /*language=TOML*/ """value = $input"""
+
+      @Serializable
+      data class Data(val value: Byte)
+
+      assertFailsWith<ParseException>(input) {
+        Toml.decodeFromString(Data.serializer(), toml)
+      }
+    }
+
+    testFails("-129")
+    testFails("128")
+  }
+
+  @Test
+  fun decodeChar() {
+    fun test(expected: Char, actual: String) {
+      val toml = /*language=TOML*/ """value = $actual"""
+
+      @Serializable
+      data class Data(val value: Char)
+
+      val data = Toml.decodeFromString(Data.serializer(), toml)
+
+      assertEquals(expected, data.value)
+    }
+
+    test((0).toChar(), "0")
+    test((-1).toChar(), "-1")
+    test((1).toChar(), "1")
+    test(Char.MAX_VALUE, "0")
+    test(Char.MIN_VALUE, "1")
+  }
+
+  @Test
+  fun decodeCharFailure() {
+    fun testFails(input: String) {
+      val toml = /*language=TOML*/ """value = $input"""
+
+      @Serializable
+      data class Data(val value: Byte)
+
+      assertFailsWith<ParseException>(input) {
+        Toml.decodeFromString(Data.serializer(), toml)
+      }
+    }
+
+    testFails("${Char.MAX_VALUE.digitToInt() + 1}")
+    testFails("${Char.MIN_VALUE.digitToInt() - 1}")
+  }
+
+  @Test
+  fun decodeShort() {
+    val toml = /*language=TOML*/ """value = 1"""
+
+    @Serializable
+    data class Data(val value: Short)
+
+    val data = Toml.decodeFromString(Data.serializer(), toml)
+
+    assertEquals(1, data.value)
+  }
+
+  @Test
+  fun decodeInt() {
+    val toml = /*language=TOML*/ """value = 1"""
+
+    @Serializable
+    data class Data(val value: Int)
+
+    val data = Toml.decodeFromString(Data.serializer(), toml)
+
+    assertEquals(1, data.value)
+  }
+
+  @Test
+  fun decodeLong() {
+    val toml = /*language=TOML*/ """value = 1"""
+
+    @Serializable
+    data class Data(val value: Long)
+
+    val data = Toml.decodeFromString(Data.serializer(), toml)
+
+    assertEquals(1, data.value)
+  }
+
+  @Test
+  fun decodeFloat() {
+    val toml = /*language=TOML*/ """value = 1"""
+
+    @Serializable
+    data class Data(val value: Double)
+
+    val data = Toml.decodeFromString(Data.serializer(), toml)
+
+    assertEquals(1.0, data.value)
+  }
+
+  @Test
+  fun decodeDouble() {
+    val toml = /*language=TOML*/ """value = 1"""
+
+    @Serializable
+    data class Data(val value: Double)
+
+    val data = Toml.decodeFromString(Data.serializer(), toml)
+
+    assertEquals(1.0, data.value)
+  }
+
+}

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/PrimitivesDecoderTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/PrimitivesDecoderTest.kt
@@ -2,145 +2,273 @@ package com.akuleshov7.ktoml.decoders
 
 import com.akuleshov7.ktoml.Toml
 import com.akuleshov7.ktoml.exceptions.ParseException
+import kotlinx.serialization.Serializable
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlinx.serialization.Serializable
 
 class PrimitivesDecoderTest {
 
-  @Test
-  fun decodeByte() {
-    fun test(expected: Byte, actual: String) {
-      val toml = /*language=TOML*/ """value = $actual"""
+    @Test
+    fun decodeByte() {
+        fun test(expected: Byte, actual: String) {
+            val toml = /*language=TOML*/ """value = $actual"""
 
-      @Serializable
-      data class Data(val value: Byte)
+            @Serializable
+            data class Data(val value: Byte)
 
-      val data = Toml.decodeFromString(Data.serializer(), toml)
+            val data = Toml.decodeFromString(Data.serializer(), toml)
 
-      assertEquals(expected, data.value)
+            assertEquals(expected, data.value)
+        }
+
+        test(0, "0")
+        test(1, "1")
+        test(-1, "-1")
+        test(-128, "-128")
+        test(127, "127")
     }
 
-    test(0, "0")
-    test(1, "1")
-    test(-1, "-1")
-    test(-128, "-128")
-    test(127, "127")
-  }
+    @Test
+    fun decodeByteFailure() {
+        fun testFails(input: String) {
+            val toml = /*language=TOML*/ """value = $input"""
 
-  @Test
-  fun decodeByteFailure() {
-    fun testFails(input: String) {
-      val toml = /*language=TOML*/ """value = $input"""
+            @Serializable
+            data class Data(val value: Byte)
 
-      @Serializable
-      data class Data(val value: Byte)
+            assertFailsWith<ParseException>(input) {
+                Toml.decodeFromString(Data.serializer(), toml)
+            }
+        }
 
-      assertFailsWith<ParseException>(input) {
-        Toml.decodeFromString(Data.serializer(), toml)
-      }
+        testFails("-129")
+        testFails("128")
     }
 
-    testFails("-129")
-    testFails("128")
-  }
+    @Test
+    fun decodeChar() {
+        fun test(expected: Char, actual: String) {
+            val toml = /*language=TOML*/ """value = $actual"""
 
-  @Test
-  fun decodeChar() {
-    fun test(expected: Char, actual: String) {
-      val toml = /*language=TOML*/ """value = $actual"""
+            @Serializable
+            data class Data(val value: Char)
 
-      @Serializable
-      data class Data(val value: Char)
+            val data = Toml.decodeFromString(Data.serializer(), toml)
 
-      val data = Toml.decodeFromString(Data.serializer(), toml)
+            assertEquals(expected, data.value)
+        }
 
-      assertEquals(expected, data.value)
+        test((0).toChar(), "0")
+        test((-1).toChar(), "-1")
+        test((1).toChar(), "1")
+        test(Char.MAX_VALUE, "0")
+        test(Char.MIN_VALUE, "1")
     }
 
-    test((0).toChar(), "0")
-    test((-1).toChar(), "-1")
-    test((1).toChar(), "1")
-    test(Char.MAX_VALUE, "0")
-    test(Char.MIN_VALUE, "1")
-  }
+    @Test
+    fun decodeCharFailure() {
+        fun testFails(input: String) {
+            val toml = /*language=TOML*/ """value = $input"""
 
-  @Test
-  fun decodeCharFailure() {
-    fun testFails(input: String) {
-      val toml = /*language=TOML*/ """value = $input"""
+            @Serializable
+            data class Data(val value: Byte)
 
-      @Serializable
-      data class Data(val value: Byte)
+            assertFailsWith<ParseException>(input) {
+                Toml.decodeFromString(Data.serializer(), toml)
+            }
+        }
 
-      assertFailsWith<ParseException>(input) {
-        Toml.decodeFromString(Data.serializer(), toml)
-      }
+        testFails("${Char.MAX_VALUE.digitToInt() + 1}")
+        testFails("${Char.MIN_VALUE.digitToInt() - 1}")
     }
 
-    testFails("${Char.MAX_VALUE.digitToInt() + 1}")
-    testFails("${Char.MIN_VALUE.digitToInt() - 1}")
-  }
+    @Test
+    fun decodeShort() {
+        fun test(expected: Short, actual: String) {
+            val toml = /*language=TOML*/ """value = $actual"""
 
-  @Test
-  fun decodeShort() {
-    val toml = /*language=TOML*/ """value = 1"""
+            @Serializable
+            data class Data(val value: Short)
 
-    @Serializable
-    data class Data(val value: Short)
+            val data = Toml.decodeFromString(Data.serializer(), toml)
 
-    val data = Toml.decodeFromString(Data.serializer(), toml)
+            assertEquals(expected, data.value)
+        }
 
-    assertEquals(1, data.value)
-  }
+        test(0, "0")
+        test(1, "1")
+        test(-1, "-1")
+        test(-128, "-128")
+        test(127, "127")
+    }
 
-  @Test
-  fun decodeInt() {
-    val toml = /*language=TOML*/ """value = 1"""
+    @Test
+    fun decodeShortFailure() {
+        fun testFails(input: String) {
+            val toml = /*language=TOML*/ """value = $input"""
 
-    @Serializable
-    data class Data(val value: Int)
+            @Serializable
+            data class Data(val value: Short)
 
-    val data = Toml.decodeFromString(Data.serializer(), toml)
+            assertFailsWith<ParseException>(input) {
+                Toml.decodeFromString(Data.serializer(), toml)
+            }
+        }
 
-    assertEquals(1, data.value)
-  }
+        testFails("${Short.MAX_VALUE.toInt() + 1}")
+        testFails("${Short.MIN_VALUE.toInt() - 1}")
+    }
 
-  @Test
-  fun decodeLong() {
-    val toml = /*language=TOML*/ """value = 1"""
+    @Test
+    fun decodeInt() {
+        fun test(expected: Int, actual: String) {
+            val toml = /*language=TOML*/ """value = $actual"""
 
-    @Serializable
-    data class Data(val value: Long)
+            @Serializable
+            data class Data(val value: Int)
 
-    val data = Toml.decodeFromString(Data.serializer(), toml)
+            val data = Toml.decodeFromString(Data.serializer(), toml)
 
-    assertEquals(1, data.value)
-  }
+            assertEquals(expected, data.value)
+        }
 
-  @Test
-  fun decodeFloat() {
-    val toml = /*language=TOML*/ """value = 1"""
+        test(0, "0")
+        test(1, "1")
+        test(-1, "-1")
+        test(-128, "-128")
+        test(127, "127")
+        test(Int.MAX_VALUE, "${Int.MAX_VALUE}")
+        test(Int.MIN_VALUE, "${Int.MIN_VALUE}")
+    }
 
-    @Serializable
-    data class Data(val value: Double)
+    @Test
+    fun decodeIntFailure() {
+        fun testFails(input: String) {
+            val toml = /*language=TOML*/ """value = $input"""
 
-    val data = Toml.decodeFromString(Data.serializer(), toml)
+            @Serializable
+            data class Data(val value: Int)
 
-    assertEquals(1.0, data.value)
-  }
+            assertFailsWith<ParseException>(input) {
+                Toml.decodeFromString(Data.serializer(), toml)
+            }
+        }
 
-  @Test
-  fun decodeDouble() {
-    val toml = /*language=TOML*/ """value = 1"""
+        testFails("${Int.MIN_VALUE.toLong() - 1}")
+        testFails("${Int.MAX_VALUE.toLong() + 1}")
+    }
 
-    @Serializable
-    data class Data(val value: Double)
+    @Test
+    fun decodeLong() {
+        fun test(expected: Long, actual: String) {
+            val toml = /*language=TOML*/ """value = $actual"""
 
-    val data = Toml.decodeFromString(Data.serializer(), toml)
+            @Serializable
+            data class Data(val value: Long)
 
-    assertEquals(1.0, data.value)
-  }
+            val data = Toml.decodeFromString(Data.serializer(), toml)
 
+            assertEquals(expected, data.value)
+        }
+
+        test(0, "0")
+        test(1, "1")
+        test(-1, "-1")
+        test(-128, "-128")
+        test(127, "127")
+        test(Long.MIN_VALUE, "${Long.MIN_VALUE}")
+        test(Long.MAX_VALUE, "${Long.MAX_VALUE}")
+    }
+
+    @Test
+    fun decodeLongFailure() {
+        fun testFails(input: String) {
+            val toml = /*language=TOML*/ """value = $input"""
+
+            @Serializable
+            data class Data(val value: Long)
+
+            assertFailsWith<ParseException>(input) {
+                Toml.decodeFromString(Data.serializer(), toml)
+            }
+        }
+
+        testFails("${Long.MIN_VALUE}0")
+        testFails("${Long.MAX_VALUE}0")
+    }
+
+    @Test
+    fun decodeFloat() {
+        fun test(expected: Float, actual: String) {
+            val toml = /*language=TOML*/ """value = $actual"""
+
+            @Serializable
+            data class Data(val value: Float)
+
+            val data = Toml.decodeFromString(Data.serializer(), toml)
+
+            assertEquals(expected, data.value)
+        }
+
+        test(0f, "0")
+        test(1f, "1")
+        test(-1f, "-1")
+        test(-128f, "-128")
+        test(127f, "127")
+    }
+
+    @Test
+    fun decodeFloatFailure() {
+        fun testFails(input: String) {
+            val toml = /*language=TOML*/ """value = $input"""
+
+            @Serializable
+            data class Data(val value: Float)
+
+            assertFailsWith<ParseException>(input) {
+                Toml.decodeFromString(Data.serializer(), toml)
+            }
+        }
+
+        testFails("-129")
+        testFails("128")
+    }
+
+    @Test
+    fun decodeDouble() {
+        fun test(expected: Double, actual: String) {
+            val toml = /*language=TOML*/ """value = $actual"""
+
+            @Serializable
+            data class Data(val value: Double)
+
+            val data = Toml.decodeFromString(Data.serializer(), toml)
+
+            assertEquals(expected, data.value)
+        }
+
+        test(0.0, "0")
+        test(1.0, "1")
+        test(-1.0, "-1")
+        test(-128.0, "-128")
+        test(127.0, "127")
+    }
+
+    @Test
+    fun decodeDoubleFailure() {
+        fun testFails(input: String) {
+            val toml = /*language=TOML*/ """value = $input"""
+
+            @Serializable
+            data class Data(val value: Double)
+
+            assertFailsWith<ParseException>(input) {
+                Toml.decodeFromString(Data.serializer(), toml)
+            }
+        }
+
+        testFails("-129")
+        testFails("128")
+    }
 }

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/encoders/PrimitiveEncoderTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/encoders/PrimitiveEncoderTest.kt
@@ -18,6 +18,7 @@ class PrimitiveEncoderTest {
             val enabled: Boolean = true,
             val pi: Double = 3.14,
             val count: Long = 3,
+            val port: Int = 8080,
             val greeting: String = "hello",
             val enumGreeting: Greeting = Greeting.Hello,
             @TomlLiteral
@@ -30,6 +31,7 @@ class PrimitiveEncoderTest {
                 enabled = true
                 pi = 3.14
                 count = 3
+                port = 8080
                 greeting = "hello"
                 enumGreeting = "hello"
                 path = 'C:\some\path\'


### PR DESCRIPTION
A quick stab at showing how non-Long numbers could be encoded and decoded. 

#163 

This is a very quick draft, I haven't spent a lot of time on it. I'm just sharing because I think the general approach is good.

This approach is based off the Kotlinx Serialization approach to handling JSON numbers

https://github.com/Kotlin/kotlinx.serialization/blob/dc950f5098162a3f8dd742d04b95f9a0405470e1/formats/json/commonMain/src/kotlinx/serialization/json/internal/StreamingJsonDecoder.kt#L281-L290

First the numbers are parsed as a Long or Double, as is already the case. Then ktoml will try to manually convert these numbers to the required type, but first verifying that the numbers are in range.

If you wanted to verify based on the raw string content, you could perhaps implement a function based on how KxS parses numbers: https://github.com/Kotlin/kotlinx.serialization/blob/dc950f5098162a3f8dd742d04b95f9a0405470e1/formats/json/commonMain/src/kotlinx/serialization/json/internal/lexer/AbstractJsonLexer.kt#L533-L584