### PR TITLE
Migration to a new 1.8 Kotlin

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     // this hack prevents the following bug: https://github.com/gradle/gradle/issues/9770
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0")
 
     implementation("org.cqfn.diktat:diktat-gradle-plugin:1.1.0")
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.15.0")

--- a/buildSrc/src/main/kotlin/com/akuleshov7/Versions.kt
+++ b/buildSrc/src/main/kotlin/com/akuleshov7/Versions.kt
@@ -4,7 +4,7 @@
     "PACKAGE_NAME_INCORRECT_PATH")
 
 object Versions {
-    const val KOTLIN = "1.7.20"
+    const val KOTLIN = "1.8.0"
     const val JUNIT = "5.7.1"
     const val OKIO = "3.1.0"
     const val SERIALIZATION = "1.4.1"

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/values/TomlBasicString.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/values/TomlBasicString.kt
@@ -96,6 +96,7 @@ public class TomlBasicString internal constructor(
                         'b' -> resultString.append('\b')
                         'r' -> resultString.append('\r')
                         'n' -> resultString.append('\n')
+                        'f' -> resultString.append('\u000C')
                         '\\' -> resultString.append('\\')
                         '\'' -> resultString.append('\'')
                         '"' -> resultString.append('"')
@@ -151,6 +152,7 @@ public class TomlBasicString internal constructor(
         private fun String.escapeSpecialCharacters(): String {
             val withCtrlCharsEscaped = replace(controlCharacterRegex) { match ->
                 when (val char = match.value.single()) {
+                    '\t' -> "\\t"
                     '\b' -> "\\b"
                     '\n' -> "\\n"
                     '\u000C' -> "\\f"

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/CharDecoderTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/CharDecoderTest.kt
@@ -1,12 +1,13 @@
 package com.akuleshov7.ktoml.decoders
 
 import com.akuleshov7.ktoml.Toml
+import com.akuleshov7.ktoml.exceptions.IllegalTypeException
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
+import kotlin.test.assertFailsWith
 
 class CharDecoderTest {
     @Serializable
@@ -25,13 +26,26 @@ class CharDecoderTest {
                 c = 'D'
             """
 
-        // FixMe #177: actually this logic is invalid, because Literal Strings should not be making a conversion of str
         val decoded = Toml.decodeFromString<MyClass>(test)
         assertEquals(decoded, MyClass('{', '4', 'D'))
     }
 
     @Test
-    @Ignore
+    fun charLiteralBasicTest() {
+        val test =
+            """
+                a = '\r'
+                b = '\n'
+                c = '\t'
+            """
+
+        assertFailsWith<IllegalTypeException> {
+            val decoded = Toml.decodeFromString<MyClass>(test)
+            assertEquals(decoded, MyClass('\r', '\n', '\t'))
+        }
+    }
+
+    @Test
     fun charUnicodeSymbolsTest() {
         val test =
             """
@@ -40,7 +54,9 @@ class CharDecoderTest {
                 c = '\u0002'
             """
 
-        val decoded = Toml.decodeFromString<MyClass>(test)
-        assertEquals(decoded, MyClass('{', '\n', '\t'))
+        assertFailsWith<IllegalTypeException> {
+            val decoded = Toml.decodeFromString<MyClass>(test)
+            assertEquals(decoded, MyClass('{', '\n', '\t'))
+        }
     }
 }

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/CustomSerializerTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/CustomSerializerTest.kt
@@ -63,7 +63,7 @@ class CustomSerializerTest {
                 """
                     rgb = "0" 
                     brg = "1"
-                """.trimIndent()
+                """
             )
         )
         UInt.MAX_VALUE
@@ -75,13 +75,13 @@ class CustomSerializerTest {
     @Test
     @Ignore
     fun testDecodingWithCustomSerializer() {
-        println(Toml.decodeFromString<Settings>(
+        Toml.decodeFromString<Settings>(
             """
                 [background]
                     rgb = "0"
                 [foreground]
                     rgb = "0"
-            """.trimIndent()
-        ))
+            """
+        )
     }
 }

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/IntegersDecoderTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/IntegersDecoderTest.kt
@@ -28,7 +28,6 @@ class IntegersDecoderTest {
             """
 
         var decoded = Toml.decodeFromString<Integers>(test)
-        println(decoded)
         assertEquals(
             Integers(5, 5, -5, 5),
             decoded
@@ -42,7 +41,6 @@ class IntegersDecoderTest {
             """
 
         decoded = Toml.decodeFromString(test)
-        println(decoded)
         assertEquals(
             Integers(32767, -128, 5, 5),
             decoded

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/StringsDecoderTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/StringsDecoderTest.kt
@@ -1,0 +1,75 @@
+package com.akuleshov7.ktoml.decoders
+
+import com.akuleshov7.ktoml.Toml
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StringDecoderTest {
+    @Serializable
+    data class Literals(
+        val winpath: String,
+        val winpath2: String,
+        val quoted: String,
+        val regex: String,
+    )
+
+    @Test
+    fun positiveScenario() {
+        var test = """
+                # What you see is what you get.
+                winpath  = 'C:\Users\nodejs\templates'
+                winpath2 = '\\ServerX\admin${'$'}\system32\'
+                quoted   = 'Tom "Dubs" Preston-Werner'
+                regex    = '<\i\c*\s*>'
+            """
+
+        var decoded = Toml.decodeFromString<Literals>(test)
+        assertEquals(
+            Literals(
+                "C:\\Users\\nodejs\\templates",
+                "\\\\ServerX\\admin${'$'}\\system32\\",
+                "Tom \"Dubs\" Preston-Werner",
+                "<\\i\\c*\\s*>"
+            ),
+            decoded
+        )
+
+        test = """
+            winpath  = '\t'
+            winpath2 = '\n'
+            quoted   = '\r'
+            regex    = '\f'
+        """
+
+        decoded = Toml.decodeFromString<Literals>(test)
+        assertEquals(
+            Literals(
+                "\\t",
+                "\\n",
+                "\\r",
+            "\\f"
+            ),
+            decoded
+        )
+
+        test = """
+            winpath  = "\t"
+            winpath2 = "\n"
+            quoted   = "\r"
+            regex    = "\f"
+        """
+
+        decoded = Toml.decodeFromString<Literals>(test)
+        assertEquals(
+            Literals(
+                "\t",
+                "\n",
+                "\r",
+                "\u000C"
+            ),
+            decoded
+        )
+    }
+}


### PR DESCRIPTION
### What's done:
- test for literal strings
- migration to Kotlin 1.8