### PR TITLE
Lower JVM target to 1.8

### DIFF
--- a/ktoml-core/build.gradle.kts
+++ b/ktoml-core/build.gradle.kts
@@ -19,9 +19,7 @@ kotlin {
     // building jvm task only on windows
     jvm {
         compilations.all {
-            kotlinOptions {
-                jvmTarget = "11"
-            }
+            kotlinOptions.jvmTarget = "1.8"
         }
     }
 

--- a/ktoml-file/build.gradle.kts
+++ b/ktoml-file/build.gradle.kts
@@ -11,9 +11,7 @@ kotlin {
 
     jvm {
         compilations.all {
-            kotlinOptions {
-                jvmTarget = "11"
-            }
+            kotlinOptions.jvmTarget = "1.8"
         }
     }
 


### PR DESCRIPTION
Allows to use ktoml (at runtime) on older JVMs. Since Kotlin currently targets 1.8 IL, there's zero difference at compile or test time.