### PR TITLE
Fixes #226 TomlTable.write() throws NoSuchElementException

### DIFF
--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/tables/TomlTable.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/tables/TomlTable.kt
@@ -76,7 +76,7 @@ public class TomlTable(
         // Todo: Option to explicitly define super tables?
         // Todo: Support dotted key-value pairs (i.e. a.b.c.d = 7)
 
-        val firstChild = children.first()
+        val firstChild = children.firstOrNull() ?: return
 
         if (isExplicit(firstChild) && type == TableType.PRIMITIVE) {
             emitter.writeHeader()

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/encoders/ArrayEncoderTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/encoders/ArrayEncoderTest.kt
@@ -18,7 +18,7 @@ class ArrayEncoderTest {
             expectedToml = "a = [ ]"
         )
     }
-
+    
     @Test
     fun simpleArrayTest() {
         @Serializable
@@ -126,6 +126,20 @@ class ArrayEncoderTest {
         assertEncodedEquals(
             value = ArrayInInlineTable(),
             expectedToml = "a = { b = [ 1, 2, 3 ] }"
+        )
+    }
+
+    @Test
+    fun emptyArrayInTableTest(){
+        @Serializable
+        data class EmbeddedData(val data: String = "embedded data")
+
+        @Serializable
+        data class EmptyListData(val content: List<EmbeddedData> = listOf() )
+        
+        assertEncodedEquals(
+            value = EmptyListData(),
+            expectedToml = ""
         )
     }
 }


### PR DESCRIPTION
Fixes #226 TomlTable.write() throws NoSuchElementExceptionthrows NoSuchElementException if children is empty