### PR TITLE
Levenshtein distance calculation for the enhancement of the 'invalid enum' error

### DIFF
--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/exceptions/TomlDecodingException.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/exceptions/TomlDecodingException.kt
@@ -29,7 +29,6 @@ internal class UnknownNameException(key: String, parent: String?) : TomlDecoding
             " to true if you would like to skip unknown keys"
 )
 
-
 @OptIn(ExperimentalSerializationApi::class)
 internal class InvalidEnumValueException(
     value: String,
@@ -37,8 +36,8 @@ internal class InvalidEnumValueException(
     lineNo: Int
 ) : TomlDecodingException(
     "Line $lineNo: value <$value> is not a valid enum option." +
-            " Permitted choices are: ${enumSerialDescriptor.elementNames.sorted().joinToString(", ")}." +
-            " Did you mean <${enumSerialDescriptor.elementNames.closestEnumName(value)}>?"
+            " Did you mean <${enumSerialDescriptor.elementNames.closestEnumName(value)}>?" +
+            " Permitted choices are: ${enumSerialDescriptor.elementNames.sorted().joinToString(", ")}."
 )
 
 internal class NullValueException(propertyName: String, lineNo: Int) : TomlDecodingException(

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/exceptions/TomlDecodingException.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/exceptions/TomlDecodingException.kt
@@ -2,6 +2,7 @@
 
 package com.akuleshov7.ktoml.exceptions
 
+import com.akuleshov7.ktoml.utils.closestEnumName
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -28,14 +29,16 @@ internal class UnknownNameException(key: String, parent: String?) : TomlDecoding
             " to true if you would like to skip unknown keys"
 )
 
+
 @OptIn(ExperimentalSerializationApi::class)
 internal class InvalidEnumValueException(
     value: String,
     enumSerialDescriptor: SerialDescriptor,
     lineNo: Int
 ) : TomlDecodingException(
-    "Value <$value> is not a valid enum option." +
-            " Permitted choices are: ${enumSerialDescriptor.elementNames.sorted().joinToString(", ")}"
+    "Line $lineNo: value <$value> is not a valid enum option." +
+            " Permitted choices are: ${enumSerialDescriptor.elementNames.sorted().joinToString(", ")}." +
+            " Did you mean <${enumSerialDescriptor.elementNames.closestEnumName(value)}>?"
 )
 
 internal class NullValueException(propertyName: String, lineNo: Int) : TomlDecodingException(

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/utils/Utils.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/utils/Utils.kt
@@ -35,3 +35,36 @@ public fun findPrimitiveTableInAstByName(children: List<TomlNode>, fullTableName
 
     return findPrimitiveTableInAstByName(children.map { it.children }.flatten(), fullTableName)
 }
+
+/**
+ * Unfortunately Levenshtein method is implemented in jline and not ported to Kotlin Native.
+ * So we need to implement it (inspired by: https://pl.kotl.in/ifo0z0vMC)
+ */
+public fun levenshteinDistance(first: String, second: String): Int {
+    when {
+        first == second -> return 0
+        first.isEmpty() -> return second.length
+        second.isEmpty() -> return first.length
+    }
+
+    val firstLen = first.length + 1
+    val secondLen = second.length + 1
+    var distance = IntArray(firstLen) { it }
+    var newDistance = IntArray(firstLen) { 0 }
+
+    for (i in 1 until secondLen) {
+        newDistance[0] = i
+        for (j in 1 until firstLen) {
+            val costReplace = distance[j - 1] + (if (first[j - 1] == second[i - 1]) 0 else 1)
+            val costInsert = distance[j] + 1
+            val costDelete = newDistance[j - 1] + 1
+
+            newDistance[j] = minOf(costInsert, costDelete, costReplace)
+        }
+        distance = newDistance.also { newDistance = distance }
+    }
+    return distance[firstLen - 1]
+}
+
+public fun Iterable<String>.closestEnumName(enumValue: String): String? =
+    this.minByOrNull { levenshteinDistance(it, enumValue) }

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/utils/Utils.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/utils/Utils.kt
@@ -9,6 +9,13 @@ import com.akuleshov7.ktoml.tree.nodes.TomlNode
 import com.akuleshov7.ktoml.tree.nodes.TomlTable
 
 /**
+ * @param enumValue input value that we need to compare with elements of enum
+ * @return nearest enum value (using levenshtein distance algorithm)
+ */
+public fun Iterable<String>.closestEnumName(enumValue: String): String? =
+    this.minByOrNull { levenshteinDistance(it, enumValue) }
+
+/**
  * Append a code point to a [StringBuilder]
  *
  * @param codePoint code point
@@ -39,12 +46,19 @@ public fun findPrimitiveTableInAstByName(children: List<TomlNode>, fullTableName
 /**
  * Unfortunately Levenshtein method is implemented in jline and not ported to Kotlin Native.
  * So we need to implement it (inspired by: https://pl.kotl.in/ifo0z0vMC)
+ *
+ * @param first string to compare
+ * @param second string for comparison
+ * @return the distance between compared strings
  */
 public fun levenshteinDistance(first: String, second: String): Int {
     when {
         first == second -> return 0
         first.isEmpty() -> return second.length
         second.isEmpty() -> return first.length
+        else -> {
+            // this is a generated else block
+        }
     }
 
     val firstLen = first.length + 1
@@ -65,6 +79,3 @@ public fun levenshteinDistance(first: String, second: String): Int {
     }
     return distance[firstLen - 1]
 }
-
-public fun Iterable<String>.closestEnumName(enumValue: String): String? =
-    this.minByOrNull { levenshteinDistance(it, enumValue) }

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/EnumValidationTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/EnumValidationTest.kt
@@ -1,0 +1,57 @@
+package com.akuleshov7.ktoml.decoders
+
+import com.akuleshov7.ktoml.Toml
+import com.akuleshov7.ktoml.exceptions.IllegalTypeException
+import com.akuleshov7.ktoml.exceptions.InvalidEnumValueException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@Serializable
+data class Color(val myEnum: EnumExample)
+
+enum class EnumExample {
+    CANAPA,
+    KANAPA,
+    KANADA,
+    USA,
+    MEXICO,
+}
+
+class EnumValidationTest {
+    @Test
+    fun testRegressions() {
+        var exception = assertFailsWith<InvalidEnumValueException> {
+            Toml.decodeFromString<Color>("myEnum = \"KANATA\"")
+        }
+
+        exception.exceptionValidation(
+            "Line 1: value <KANATA> is not a valid enum option. Did you mean <KANAPA>? " +
+                    "Permitted choices are: CANAPA, KANADA, KANAPA, MEXICO, USA."
+        )
+
+        exception = assertFailsWith<InvalidEnumValueException> {
+            Toml.decodeFromString<Color>("myEnum = \"TEST\"")
+        }
+
+        exception.exceptionValidation(
+            "Line 1: value <TEST> is not a valid enum option. Did you mean <USA>? " +
+                    "Permitted choices are: CANAPA, KANADA, KANAPA, MEXICO, USA."
+        )
+
+        exception = assertFailsWith<InvalidEnumValueException> {
+            Toml.decodeFromString<Color>("myEnum = \"MEKSICA\"")
+        }
+
+        exception.exceptionValidation(
+            "Line 1: value <MEKSICA> is not a valid enum option. Did you mean <MEXICO>? " +
+                    "Permitted choices are: CANAPA, KANADA, KANAPA, MEXICO, USA."
+        )
+    }
+}
+
+private fun InvalidEnumValueException.exceptionValidation(expected: String) {
+    assertEquals(expected, this.message)
+}


### PR DESCRIPTION
### What's done:
- Inspired by Diktat: in most configuration files, we use enums, and authors of libraries working with these configuration files would like to assist users in identifying any misprints and suggesting the closest valid values
- Actually I believe that this functionality should be implemented in all decoding libraries