### PR TITLE
Initial Support for Simple Map decoding with unnamed toml keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,10 @@ gradle-libs-like-property = { id = "org.jetbrains.kotlin.jvm", version.ref = "ko
     property1 = 100
     property2 = 6
 
+[myMap]
+    a = "b"
+    c = "d"
+
 [table2]
     someNumber = 5
 [table2."akuleshov7.com"]
@@ -312,7 +316,8 @@ data class MyClass(
     val table1: Table1,
     val table2: Table2,
     @SerialName("gradle-libs-like-property")
-    val kotlinJvm: GradlePlugin
+    val kotlinJvm: GradlePlugin,
+    val myMap: Map<String, String>
 )
 
 @Serializable

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/decoders/TomlArrayDecoder.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/decoders/TomlArrayDecoder.kt
@@ -1,6 +1,5 @@
 package com.akuleshov7.ktoml.decoders
 
-import com.akuleshov7.ktoml.TomlConfig
 import com.akuleshov7.ktoml.TomlInputConfig
 import com.akuleshov7.ktoml.tree.nodes.TomlKeyValue
 import com.akuleshov7.ktoml.tree.nodes.TomlKeyValueArray
@@ -29,14 +28,6 @@ public class TomlArrayDecoder(
     override val serializersModule: SerializersModule = EmptySerializersModule()
     private lateinit var currentElementDecoder: TomlPrimitiveDecoder
     private lateinit var currentPrimitiveElementOfArray: TomlValue
-
-    @Deprecated(
-        message = "TomlConfig is deprecated; use TomlInputConfig instead. Will be removed in next releases."
-    )
-    public constructor(
-        rootNode: TomlKeyValueArray,
-        config: TomlConfig
-    ) : this(rootNode, config.input)
 
     private fun haveStartedReadingElements() = nextElementIndex > 0
 
@@ -90,6 +81,6 @@ public class TomlArrayDecoder(
         super.decodeSerializableValue(deserializer)
     }
 
-    // this should be applied to [currentPrimitiveElementOfArray] and not to the [rootNode], because
+    // this should be applied to [currentPrimitiveElementOfArray] and not to the [rootNode]
     override fun decodeNotNullMark(): Boolean = currentPrimitiveElementOfArray !is TomlNull
 }

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/decoders/TomlMapDecoder.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/decoders/TomlMapDecoder.kt
@@ -1,0 +1,27 @@
+import com.akuleshov7.ktoml.decoders.TomlAbstractDecoder
+import com.akuleshov7.ktoml.tree.nodes.TomlKeyValue
+import com.akuleshov7.ktoml.tree.nodes.TomlKeyValuePrimitive
+import com.akuleshov7.ktoml.tree.nodes.TomlTable
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.modules.EmptySerializersModule
+import kotlinx.serialization.modules.SerializersModule
+
+/**
+ * @property rootNode
+ */
+@ExperimentalSerializationApi
+public class TomlMapDecoder(
+    private val rootNode: TomlTable,
+) : TomlAbstractDecoder() {
+    override val serializersModule: SerializersModule = EmptySerializersModule()
+    override fun decodeValue(): Any = rootNode.children.map {
+        when(it) {
+            is TomlKeyValue -> it.key to it.value
+            else -> throw Exception()
+        }
+    }
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int = 0
+
+    override fun decodeKeyValue(): TomlKeyValue = throw NotImplementedError("")
+}

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/decoders/TomlMapDecoder.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/decoders/TomlMapDecoder.kt
@@ -1,27 +1,71 @@
-import com.akuleshov7.ktoml.decoders.TomlAbstractDecoder
+package com.akuleshov7.ktoml.decoders
+
+import com.akuleshov7.ktoml.exceptions.UnsupportedDecoderException
 import com.akuleshov7.ktoml.tree.nodes.TomlKeyValue
-import com.akuleshov7.ktoml.tree.nodes.TomlKeyValuePrimitive
 import com.akuleshov7.ktoml.tree.nodes.TomlTable
+import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.CompositeDecoder
 import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.SerializersModule
 
 /**
- * @property rootNode
+ * Sometimes, when you do not know the names of the TOML keys and cannot create a proper class with field names for parsing,
+ * it can be useful to read and parse TOML tables to a map. This is exactly what this TomlMapDecoder is used for.
+ *
+ * @property rootNode toml table that we are trying to decode
+ * @property decodingElementIndex for iterating over the TOML table we are currently reading
+ * @property kotlinxIndex for iteration inside the kotlinX loop: [decodeElementIndex -> decodeSerializableElement]
  */
 @ExperimentalSerializationApi
 public class TomlMapDecoder(
     private val rootNode: TomlTable,
+    private var decodingElementIndex: Int = 0,
+    private var kotlinxIndex: Int = 0,
 ) : TomlAbstractDecoder() {
     override val serializersModule: SerializersModule = EmptySerializersModule()
-    override fun decodeValue(): Any = rootNode.children.map {
-        when(it) {
-            is TomlKeyValue -> it.key to it.value
-            else -> throw Exception()
-        }
-    }
-    override fun decodeElementIndex(descriptor: SerialDescriptor): Int = 0
 
-    override fun decodeKeyValue(): TomlKeyValue = throw NotImplementedError("")
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
+        // we will iterate in the following way:
+        // for [map]
+        // a = 1
+        // b = 2
+        // kotlinxIndex will be 0, 1, 2 ,3
+        // and decodingElementIndex will be 0, 1 (as there are only two elements in the table: 'a' and 'b')
+        decodingElementIndex = kotlinxIndex / 2
+
+        if (decodingElementIndex == rootNode.children.size) {
+            return CompositeDecoder.DECODE_DONE
+        }
+
+        return kotlinxIndex++
+    }
+
+    override fun <T> decodeSerializableElement(
+        descriptor: SerialDescriptor,
+        index: Int,
+        deserializer: DeserializationStrategy<T>,
+        previousValue: T?
+    ): T {
+        val returnValue = when (val processedNode = rootNode.children[decodingElementIndex]) {
+            // simple decoding for key-value type
+            is TomlKeyValue -> processedNode
+            else -> throw UnsupportedDecoderException(
+                """ Attempting to decode <$rootNode>; however, custom Map decoders do not currently support nested structures.
+                Decoding is limited to plain structures only: 
+                [map]
+                    a = 1 
+                    b = 2
+                    c = "3"
+            """
+            )
+        }
+
+        return ((if (index % 2 == 0) returnValue.key.toString() else returnValue.value.content)) as T
+    }
+
+    override fun decodeKeyValue(): TomlKeyValue {
+        TODO("No need to implement decodeKeyValue for TomlMapDecoder as it is not needed for such primitive decoders")
+    }
 }

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/exceptions/TomlDecodingException.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/exceptions/TomlDecodingException.kt
@@ -48,3 +48,4 @@ internal class NullValueException(propertyName: String, lineNo: Int) : TomlDecod
 internal class IllegalTypeException(message: String, lineNo: Int) : TomlDecodingException("Line $lineNo: $message")
 
 internal class MissingRequiredPropertyException(message: String) : TomlDecodingException(message)
+internal class UnsupportedDecoderException(message: String) : TomlDecodingException(message)

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/PlainMapDecoderTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/PlainMapDecoderTest.kt
@@ -1,0 +1,79 @@
+package com.akuleshov7.ktoml.decoders
+
+import com.akuleshov7.ktoml.Toml
+
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+
+class PlainMapDecoderTest {
+    @Serializable
+    private data class TestDataMap(
+        val text: String,
+        val map: Map<String, String>,
+        val number: Int,
+    )
+
+    @Test
+    fun testMapDecoderPositiveCase() {
+        var data = """
+            text = "Test"
+            number = 15
+            [map]
+              a = 1
+              b = 1
+              c = 1
+              number = 31
+        """.trimIndent()
+
+        Toml.decodeFromString<TestDataMap>(data)
+
+        data = """
+            map = { a = 1,  b = 2, c = 3 }
+            text = "Test"
+            number = 15
+        """.trimIndent()
+
+        Toml.decodeFromString<TestDataMap>(data)
+    }
+
+    @Test
+    fun testMapDecoderNegativeCases() {
+        var data = """
+            a = 1
+            b = 1 
+            c = 1
+            text = "Test"
+            number = 15
+        """.trimIndent()
+
+        Toml.decodeFromString<TestDataMap>(data)
+
+        data = """
+            [map]
+                [map.a]
+                     b = 1
+                [map.b]
+                     c = 1
+            text = "Test"
+            number = 15
+        """.trimIndent()
+
+        Toml.decodeFromString<TestDataMap>(data)
+
+        data = """
+            text = "Test"
+            number = 15
+        """.trimIndent()
+
+        Toml.decodeFromString<TestDataMap>(data)
+    }
+
+    @Test
+    fun testSimpleMapDecoder() {
+        val data = TestDataMap(text = "text value", number = 7321, map = mapOf("a" to "b", "c" to "d"))
+        val encoded = Toml.encodeToString(data)
+        val decoded: TestDataMap = Toml.decodeFromString(encoded) // throws MissingRequiredPropertyException
+    }
+}

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/ReadMeExampleTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/ReadMeExampleTest.kt
@@ -15,7 +15,8 @@ class ReadMeExampleTest {
         val table1: Table1,
         val table2: Table2,
         @SerialName("gradle-libs-like-property")
-        val kotlinJvm: GradlePlugin
+        val kotlinJvm: GradlePlugin,
+        val myMap: Map<String, String>
     )
 
     @Serializable
@@ -68,6 +69,10 @@ class ReadMeExampleTest {
               # so for 'property1' null value is ok. Use: property1 = null  
               property1 = 100 
               property2 = 6
+              
+            [myMap]
+              a = "b"
+              c = "d"
              
             [table2]
               someNumber = 5
@@ -107,7 +112,8 @@ class ReadMeExampleTest {
                     charFromInteger = '{'
                 ),
 
-                kotlinJvm = GradlePlugin("org.jetbrains.kotlin.jvm", Version("kotlin"))
+                kotlinJvm = GradlePlugin("org.jetbrains.kotlin.jvm", Version("kotlin")),
+                myMap = mapOf("a" to "b", "c" to "d")
             ),
             decoded
         )


### PR DESCRIPTION
### What's done:

- Phaze 1: only primitive tables (without nested multiple tables) with no explicit  type checking.
- The idea is to decode unnamed arguments.
For example: 
```
[map]
a = 1
b = 2 
```

or 
```
map = {a=1, b=2}
```

Should be decoded (without knowing and naming explicitly toml keys) to:
```
data class Test {
    val map: Map<String, Int>
}
```

Guys like @jakubgwozdz @y9san9 requested it and it looks like it can be useful for parsing gradle configs.