### PR TITLE
Primitive Char should be encoded with a single quote

### DIFF
--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/encoders/TomlAbstractEncoder.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/encoders/TomlAbstractEncoder.kt
@@ -152,7 +152,14 @@ public abstract class TomlAbstractEncoder protected constructor(
     override fun encodeShort(value: Short): Unit = encodeLong(value.toLong())
     override fun encodeInt(value: Int): Unit = encodeLong(value.toLong())
     override fun encodeFloat(value: Float): Unit = encodeDouble(value.toDouble())
-    override fun encodeChar(value: Char): Unit = encodeString(value.toString())
+
+    /**
+     * https://github.com/akuleshov7/ktoml/issues/260
+     * As per the TOML specification, there is no predefined Char type.
+     * However, we've introduced the concept in our TOML implementation to align more closely with Kotlin's syntax.
+     * So we are expecting Chars to have single quote on the decoding. So encoding should be done in a similar way.
+     */
+    override fun encodeChar(value: Char): Unit = appendValue(TomlLiteralString(value.toString()))
 
     // Structure
 

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/encoders/PrimitiveEncoderTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/encoders/PrimitiveEncoderTest.kt
@@ -126,4 +126,17 @@ class PrimitiveEncoderTest {
             expectedToml = "wholeNumberDouble = 3.0"
         )
     }
+
+    @Test
+    fun charRegression() {
+        @Serializable
+        data class File(
+            val charVal: Char = 'W'
+        )
+
+        assertEncodedEquals(
+            value = File(),
+            expectedToml = "charVal = \'W\'"
+        )
+    }
 }


### PR DESCRIPTION
### What's done:
- As per the TOML specification, there is no predefined Char type. However, we've introduced the concept in our TOML implementation to align more closely with Kotlin's syntax. So we are expecting Chars to have single quote on the decoding. We need to make it more convenient and do encoding and decoding in a similar way.