### PR TITLE
Use isEmpty() for size check & fix missing noun reported by spell check

### DIFF
--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/TomlNode.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/TomlNode.kt
@@ -57,9 +57,9 @@ public sealed class TomlNode(
     )
 
     /**
-     * @return true if has no children
+     * @return true if node has no children
      */
-    public fun hasNoChildren(): Boolean = children.size == 0
+    public fun hasNoChildren(): Boolean = children.isEmpty()
 
     /**
      * @return first child or null


### PR DESCRIPTION
This PR is based on two hints I got from IntelliJ while browsing the code base:

1. `children.isEmpty()` is a bit simpler than size comparison with 0
2. Spell check reported missing noun in comment, so I added `node` to the comment.