### PR TITLE
Add regression tests for issue #361 (empty lines after table headers)

### DIFF
--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/parsers/RealWorldPythonProjectTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/parsers/RealWorldPythonProjectTest.kt
@@ -1,0 +1,99 @@
+package com.akuleshov7.ktoml.parsers
+
+import com.akuleshov7.ktoml.Toml
+import com.akuleshov7.ktoml.TomlInputConfig
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+
+/**
+ * Real-world test cases from popular Python projects.
+ * These tests validate ktoml against actual pyproject.toml files used in production.
+ */
+class RealWorldPythonProjectTest {
+
+    @Serializable
+    data class TestProject(
+        val project: ProjectSection
+    )
+
+    @Serializable
+    data class ProjectSection(
+        val name: String,
+        val version: String
+    )
+
+    @Serializable
+    data class SimpleTable(
+        val table: TableContent
+    )
+
+    @Serializable
+    data class TableContent(
+        val key: String
+    )
+
+    /**
+     * Test parsing FastAPI's pyproject.toml structure.
+     *
+     * FastAPI has an empty line after [project.optional-dependencies] which is valid TOML
+     * but triggers a ktoml parser bug:
+     * https://github.com/orchestr7/ktoml/issues/361
+     */
+    @Test
+    fun testFastAPIStyleEmptyLineAfterTableHeader() {
+        val toml = """
+            [project]
+            name = "fastapi"
+            version = "0.115.6"
+
+            [project.optional-dependencies]
+
+            standard = [
+                "fastapi-cli[standard] >=0.0.8",
+                "httpx >=0.23.0"
+            ]
+        """.trimIndent()
+
+        // This should parse successfully - empty lines after table headers are valid TOML
+        // Test that the parser can handle this structure
+        val parser = TomlParser(TomlInputConfig())
+        val tree = parser.parseString(toml)
+        assertNotNull(tree)
+        assertTrue(tree.children.isNotEmpty())
+    }
+
+    /**
+     * Simplified reproduction of the empty line issue.
+     */
+    @Test
+    fun testEmptyLineAfterTableHeader() {
+        val toml = """
+            [table]
+
+            key = "value"
+        """.trimIndent()
+
+        // Empty lines after table headers should be allowed
+        val result = Toml.decodeFromString<SimpleTable>(toml)
+        assertNotNull(result)
+    }
+
+    /**
+     * Test multiple empty lines after table header.
+     */
+    @Test
+    fun testMultipleEmptyLinesAfterTableHeader() {
+        val toml = """
+            [table]
+
+
+            key = "value"
+        """.trimIndent()
+
+        val result = Toml.decodeFromString<SimpleTable>(toml)
+        assertNotNull(result)
+    }
+}

--- a/ktoml-core/src/jvmTest/kotlin/Issue361Test.kt
+++ b/ktoml-core/src/jvmTest/kotlin/Issue361Test.kt
@@ -1,0 +1,130 @@
+package com.akuleshov7.ktoml.parsers
+
+import com.akuleshov7.ktoml.Toml
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@Serializable
+data class ProjectOptionalDeps(
+    val standard: List<String>
+)
+
+@Serializable
+data class Project(
+    val name: String,
+    val version: String,
+    val `optional-dependencies`: ProjectOptionalDeps
+)
+
+@Serializable
+data class PyProject(
+    val project: Project
+)
+
+/**
+ * Regression tests for issue #361: Empty lines after table headers
+ * https://github.com/orchestr7/ktoml/issues/361
+ *
+ * These tests verify that ktoml correctly handles empty lines after TOML table headers,
+ * which is valid TOML 1.0 but was previously causing parsing failures.
+ */
+class Issue361Test {
+
+    @Test
+    fun testFastAPIWithEmptyLineAfterTableHeader() {
+        // This is the exact TOML structure from issue #361 (FastAPI pyproject.toml)
+        // Previously failed with: MissingRequiredPropertyException
+        val toml = """
+[project]
+name = "fastapi"
+version = "0.115.6"
+
+[project.optional-dependencies]
+
+standard = [
+    "fastapi-cli[standard] >=0.0.8",
+    "httpx >=0.23.0"
+]
+        """.trimIndent()
+
+        val parsed = Toml.decodeFromString<PyProject>(toml)
+        assertEquals("fastapi", parsed.project.name)
+        assertEquals("0.115.6", parsed.project.version)
+        assertEquals(2, parsed.project.`optional-dependencies`.standard.size)
+        assertEquals("fastapi-cli[standard] >=0.0.8", parsed.project.`optional-dependencies`.standard[0])
+    }
+
+    @Test
+    fun testMultipleEmptyLinesAfterTableHeader() {
+        // Test with multiple consecutive empty lines
+        val toml = """
+[project]
+name = "test"
+version = "1.0.0"
+
+[project.optional-dependencies]
+
+
+
+standard = ["dep1", "dep2"]
+        """.trimIndent()
+
+        val parsed = Toml.decodeFromString<PyProject>(toml)
+        assertEquals("test", parsed.project.name)
+        assertEquals(2, parsed.project.`optional-dependencies`.standard.size)
+    }
+
+    @Test
+    fun testEmptyLinesWithCommentsAfterTableHeader() {
+        // Test empty lines mixed with comments
+        val toml = """
+[project]
+name = "test"
+version = "1.0.0"
+
+[project.optional-dependencies]
+
+# This is a comment
+
+standard = ["dep1"]
+        """.trimIndent()
+
+        val parsed = Toml.decodeFromString<PyProject>(toml)
+        assertEquals(1, parsed.project.`optional-dependencies`.standard.size)
+    }
+
+    @Test
+    fun testNestedTableWithEmptyLineAfterHeader() {
+        // Test deeply nested tables with empty lines
+        val toml = """
+[a.b.c]
+
+value = "test"
+        """.trimIndent()
+
+        val parsed = Toml.decodeFromString<DeepNested>(toml)
+        assertEquals("test", parsed.a.b.c.value)
+    }
+}
+
+@Serializable
+data class DeepNested(
+    val a: ALevel
+)
+
+@Serializable
+data class ALevel(
+    val b: BLevel
+)
+
+@Serializable
+data class BLevel(
+    val c: CLevel
+)
+
+@Serializable
+data class CLevel(
+    val value: String
+)


### PR DESCRIPTION
## Summary

This PR adds comprehensive regression tests for issue #361, which reported that ktoml failed to parse valid TOML files with empty lines after table headers.

## Background

Issue #361 reported parsing failures when empty lines appeared after TOML table headers (a pattern found in popular Python projects like FastAPI and Black). For example:

```toml
[project.optional-dependencies]

standard = [
    "fastapi-cli[standard] >=0.0.8",
    "httpx >=0.23.0"
]
```

This is valid TOML 1.0, but was previously causing `MissingRequiredPropertyException` in ktoml 0.7.1.

## Resolution

✅ **All regression tests pass on the current main branch**, indicating the issue has been resolved.

The fix likely came through one of these recent PRs:
- #353 - Support decoding map with array
- #334 - Fix behavior of dotted keys inside array-of-tables
- #333 - Fixes around comments in/around multiline strings

## Test Coverage

This PR adds two test files with comprehensive coverage:

### `Issue361Test.kt` (JVM-specific tests)
1. **testFastAPIWithEmptyLineAfterTableHeader** - Exact FastAPI pyproject.toml pattern
2. **testMultipleEmptyLinesAfterTableHeader** - Multiple consecutive empty lines
3. **testEmptyLinesWithCommentsAfterTableHeader** - Empty lines mixed with comments
4. **testNestedTableWithEmptyLineAfterHeader** - Deeply nested tables

### `RealWorldPythonProjectTest.kt` (Cross-platform tests)
1. **testFastAPIStyleEmptyLineAfterTableHeader** - Parser-level validation
2. **testEmptyLineAfterTableHeader** - Minimal reproduction case
3. **testMultipleEmptyLinesAfterTableHeader** - Edge case coverage

## Testing

All tests pass:
```
✓ 7 new regression tests
✓ All existing tests continue to pass
✓ No regressions introduced
```

## Impact

These regression tests ensure that:
- The fix for #361 remains stable in future releases
- ktoml continues to correctly parse real-world `pyproject.toml` files from popular Python projects
- TOML 1.0 spec compliance is maintained for empty lines after table headers

Closes #361

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)