### PR TITLE
Integrate toml-lang/toml-test compliance suite

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,6 +24,9 @@ jobs:
     steps:
       # actions/checkout v1.* is needed for correct codecov upload, see https://github.com/actions/checkout/issues/237 for details
       - uses: actions/checkout@v6
+        with:
+          # toml-test compliance suite lives in a git submodule; fetch it so the tests can run
+          submodules: recursive
       # ensure that gradle wrapper files in repository are valid by checking checksums
       - uses: gradle/actions/wrapper-validation@v5
       - name: Set up JDK 21

--- a/.github/workflows/kjs-yarn-update.yml
+++ b/.github/workflows/kjs-yarn-update.yml
@@ -13,6 +13,10 @@ on:
 jobs:
   update_kjs_yarn_lock:
     runs-on: ubuntu-latest
+    # This job regenerates yarn.lock and pushes it back to the source branch, which only works
+    # for branches in this repository. Skip it for pull requests opened from forks: the branch
+    # cannot be checked out from this origin and the push-back step would have no write access.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v6
         if: github.event_name == 'pull_request'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "toml-test"]
+	path = toml-test
+	url = https://github.com/toml-lang/toml-test.git

--- a/README.md
+++ b/README.md
@@ -574,3 +574,11 @@ data class CoinsConfiguration(
 
 
 </details>
+
+## Compliance Testing
+
+ktoml is tested against the [toml-lang/toml-test](https://github.com/toml-lang/toml-test) suite (TOML 1.0). Known failures are tracked with upstream issues.
+
+See [`TomlTestBaseline.kt`](ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt) for the full baseline, failure categories, and linked issues.
+
+Related: [#32 — Integrate toml-test compliance suite](https://github.com/orchestr7/ktoml/issues/32)

--- a/ktoml-core/build.gradle.kts
+++ b/ktoml-core/build.gradle.kts
@@ -93,6 +93,8 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-junit5"))
                 implementation("org.junit.jupiter:junit-jupiter-engine:5.14.1")
+                implementation("org.junit.jupiter:junit-jupiter-params:5.14.1")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:${Versions.SERIALIZATION}")
             }
         }
         all {

--- a/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
+++ b/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
@@ -1,0 +1,406 @@
+package com.akuleshov7.ktoml.compliance
+
+/**
+ * Known failures for the [toml-lang/toml-test](https://github.com/toml-lang/toml-test) compliance suite.
+ *
+ * Each [KnownFailure] object declares an issue ID and a list of test paths that fail due to that issue.
+ * When a bug is fixed, the test will start passing and [TomlTestSuite] will fail with an
+ * XPASS message — remove the test path from the corresponding object.
+ *
+ * ## Failure categories
+ *
+ * | Category | Issue |
+ * |----------|-------|
+ * | Datetime offset normalized to UTC | [#375](https://github.com/orchestr7/ktoml/issues/375) |
+ * | Float representation lost | [#376](https://github.com/orchestr7/ktoml/issues/376) |
+ * | Dotted key expansion incorrect | [#377](https://github.com/orchestr7/ktoml/issues/377) |
+ * | Array-of-tables structure | [#378](https://github.com/orchestr7/ktoml/issues/378) |
+ * | Key names not unquoted | [#379](https://github.com/orchestr7/ktoml/issues/379) |
+ * | Parser rejects valid TOML | [#380](https://github.com/orchestr7/ktoml/issues/380) |
+ * | Stack overflow on deep nesting | [#381](https://github.com/orchestr7/ktoml/issues/381) |
+ * | Multiline string escape handling | [#382](https://github.com/orchestr7/ktoml/issues/382) |
+ * | Multiline inline table crash | [#374](https://github.com/orchestr7/ktoml/issues/374) |
+ * | Missing validation (accepts invalid) | [#383](https://github.com/orchestr7/ktoml/issues/383) |
+ *
+ * Related: [#32](https://github.com/orchestr7/ktoml/issues/32) (toml-test integration),
+ * [#373](https://github.com/orchestr7/ktoml/issues/373) (TOML 1.1 umbrella)
+ */
+sealed interface KnownFailure {
+    val issue: Int
+    val tests: List<String>
+
+    val issueUrl: String get() = "https://github.com/orchestr7/ktoml/issues/$issue"
+}
+
+/** Offset datetimes normalized to UTC, losing original timezone */
+data object DatetimeOffsetLoss : KnownFailure {
+    override val issue = 375
+    override val tests = listOf(
+        "valid/comment/everywhere.toml",
+        "valid/datetime/milliseconds.toml",
+        "valid/datetime/timezone.toml",
+        "valid/spec-1.0.0/offset-date-time-0.toml",
+        "valid/spec-example-1.toml",
+        "valid/spec-example-1-compact.toml",
+    )
+}
+
+/** Scientific notation lost after parsing to Double */
+data object FloatRepresentationLoss : KnownFailure {
+    override val issue = 376
+    override val tests = listOf(
+        "valid/float/exponent.toml",
+        "valid/spec-1.0.0/float-0.toml",
+    )
+}
+
+/** Dotted keys don't always create correct synthetic nested tables */
+data object DottedKeyExpansion : KnownFailure {
+    override val issue = 377
+    override val tests = listOf(
+        "valid/inline-table/key-dotted-01.toml",
+        "valid/inline-table/key-dotted-02.toml",
+        "valid/inline-table/key-dotted-04.toml",
+        "valid/inline-table/key-dotted-06.toml",
+        "valid/key/dotted-01.toml",
+        "valid/key/dotted-02.toml",
+        "valid/key/dotted-04.toml",
+        "valid/key/dotted-empty.toml",
+        "valid/key/quoted-dots.toml",
+    )
+}
+
+/** Array-of-tables produces wrong AST structure in edge cases */
+data object ArrayOfTablesStructure : KnownFailure {
+    override val issue = 378
+    override val tests = listOf(
+        "valid/array/open-parent-table.toml",
+        "valid/table/array-empty-name.toml",
+        "valid/table/array-implicit.toml",
+        "valid/table/array-implicit-and-explicit-after.toml",
+        "valid/table/array-table-array.toml",
+    )
+}
+
+/** Key names retain quote characters in AST name property */
+data object KeyNameQuoting : KnownFailure {
+    override val issue = 379
+    override val tests = listOf(
+        "valid/key/space.toml",
+        "valid/multibyte.toml",
+        "valid/spec-1.0.0/table-3.toml",
+        "valid/table/empty-name.toml",
+        "valid/table/with-literal-string.toml",
+        "valid/table/with-single-quotes.toml",
+    )
+}
+
+/** ktoml rejects valid TOML with ParseException */
+data object ValidTomlRejected : KnownFailure {
+    override val issue = 380
+    override val tests = listOf(
+        "valid/array/mixed-string-table.toml",
+        "valid/array/table-array-string-backslash.toml",
+        "valid/datetime/edge.toml",
+        "valid/datetime/leap-year.toml",
+        "valid/datetime/local.toml",
+        "valid/float/max-int.toml",
+        "valid/float/underscore.toml",
+        "valid/inline-table/key-dotted-05.toml",
+        "valid/inline-table/nest.toml",
+        "valid/key/escapes.toml",
+        "valid/key/quoted-unicode.toml",
+        "valid/key/special-chars.toml",
+        "valid/spec-1.0.0/array-0.toml",
+        "valid/spec-1.0.0/float-1.toml",
+        "valid/spec-1.0.0/keys-1.toml",
+        "valid/table/names.toml",
+        "valid/table/names-with-values.toml",
+    )
+}
+
+/** Stack overflow on deeply nested structures */
+data object StackOverflowOnNesting : KnownFailure {
+    override val issue = 381
+    override val tests = listOf(
+        "valid/array/nested-double.toml",
+        "valid/comment/tricky.toml",
+    )
+}
+
+/** Line-ending backslash in multiline strings not handled correctly */
+data object MultilineStringEscape : KnownFailure {
+    override val issue = 382
+    override val tests = listOf(
+        "valid/string/ends-in-whitespace-escape.toml",
+        "valid/string/multiline.toml",
+        "valid/string/multiline-empty.toml",
+    )
+}
+
+/** Multiline inline tables crash with "character count -1" */
+data object MultilineInlineTableCrash : KnownFailure {
+    override val issue = 374
+    override val tests = listOf(
+        "valid/inline-table/array-02.toml",
+        "valid/inline-table/array-03.toml",
+        "valid/inline-table/key-dotted-07.toml",
+        "valid/inline-table/multiline.toml",
+    )
+}
+
+/** Missing validation — control characters not rejected */
+data object MissingValidationControlChars : KnownFailure {
+    override val issue = 383
+    override val tests = listOf(
+        "invalid/control/bare-cr.toml",
+        "invalid/control/comment-cr.toml",
+        "invalid/control/comment-del.toml",
+        "invalid/control/comment-ff.toml",
+        "invalid/control/comment-lf.toml",
+        "invalid/control/comment-null.toml",
+        "invalid/control/comment-us.toml",
+        "invalid/control/multi-del.toml",
+        "invalid/control/multi-lf.toml",
+        "invalid/control/multi-null.toml",
+        "invalid/control/multi-us.toml",
+        "invalid/control/only-ff.toml",
+        "invalid/control/only-vt.toml",
+        "invalid/control/rawmulti-del.toml",
+        "invalid/control/rawmulti-lf.toml",
+        "invalid/control/rawmulti-null.toml",
+        "invalid/control/rawmulti-us.toml",
+        "invalid/control/rawstring-cr.toml",
+        "invalid/control/rawstring-del.toml",
+        "invalid/control/rawstring-lf.toml",
+        "invalid/control/rawstring-null.toml",
+        "invalid/control/rawstring-us.toml",
+        "invalid/control/string-bs.toml",
+        "invalid/control/string-cr.toml",
+        "invalid/control/string-del.toml",
+        "invalid/control/string-lf.toml",
+        "invalid/control/string-null.toml",
+        "invalid/control/string-us.toml",
+    )
+}
+
+/** Missing validation — bad UTF-8 encoding not rejected */
+data object MissingValidationEncoding : KnownFailure {
+    override val issue = 383
+    override val tests = listOf(
+        "invalid/encoding/bad-codepoint.toml",
+        "invalid/encoding/bad-utf8-in-comment.toml",
+        "invalid/encoding/bad-utf8-in-multiline.toml",
+        "invalid/encoding/bad-utf8-in-multiline-literal.toml",
+        "invalid/encoding/bad-utf8-in-string.toml",
+        "invalid/encoding/bad-utf8-in-string-literal.toml",
+        "invalid/encoding/ideographic-space.toml",
+    )
+}
+
+/** Missing validation — table redefinition and duplicate keys not rejected */
+data object MissingValidationTableRedefinition : KnownFailure {
+    override val issue = 383
+    override val tests = listOf(
+        "invalid/table/append-with-dotted-keys-01.toml",
+        "invalid/table/append-with-dotted-keys-02.toml",
+        "invalid/table/append-with-dotted-keys-03.toml",
+        "invalid/table/append-with-dotted-keys-04.toml",
+        "invalid/table/append-with-dotted-keys-05.toml",
+        "invalid/table/append-with-dotted-keys-06.toml",
+        "invalid/table/append-with-dotted-keys-07.toml",
+        "invalid/table/append-with-dotted-keys-08.toml",
+        "invalid/table/array-implicit.toml",
+        "invalid/table/dot.toml",
+        "invalid/table/dotdot.toml",
+        "invalid/table/duplicate-key-01.toml",
+        "invalid/table/duplicate-key-02.toml",
+        "invalid/table/duplicate-key-03.toml",
+        "invalid/table/duplicate-key-04.toml",
+        "invalid/table/duplicate-key-05.toml",
+        "invalid/table/duplicate-key-06.toml",
+        "invalid/table/duplicate-key-07.toml",
+        "invalid/table/duplicate-key-08.toml",
+        "invalid/table/duplicate-key-09.toml",
+        "invalid/table/duplicate-key-10.toml",
+        "invalid/table/empty-implicit-table.toml",
+        "invalid/table/multiline-key-01.toml",
+        "invalid/table/multiline-key-02.toml",
+        "invalid/table/overwrite-array-in-parent.toml",
+        "invalid/table/overwrite-bool-with-array.toml",
+        "invalid/table/overwrite-with-deep-table.toml",
+        "invalid/table/redefine-01.toml",
+        "invalid/table/redefine-02.toml",
+        "invalid/table/redefine-03.toml",
+        "invalid/table/super-twice.toml",
+        "invalid/table/trailing-dot.toml",
+    )
+}
+
+/** Missing validation — malformed integer literals not rejected */
+data object MissingValidationIntegerFormat : KnownFailure {
+    override val issue = 383
+    override val tests = listOf(
+        "invalid/integer/double-us.toml",
+        "invalid/integer/invalid-hex-03.toml",
+        "invalid/integer/leading-us.toml",
+        "invalid/integer/leading-us-bin.toml",
+        "invalid/integer/leading-us-hex.toml",
+        "invalid/integer/leading-us-oct.toml",
+        "invalid/integer/leading-zero-01.toml",
+        "invalid/integer/leading-zero-02.toml",
+        "invalid/integer/leading-zero-03.toml",
+        "invalid/integer/leading-zero-sign-01.toml",
+        "invalid/integer/leading-zero-sign-02.toml",
+        "invalid/integer/leading-zero-sign-03.toml",
+        "invalid/integer/trailing-us.toml",
+        "invalid/integer/trailing-us-bin.toml",
+        "invalid/integer/trailing-us-hex.toml",
+        "invalid/integer/trailing-us-oct.toml",
+        "invalid/integer/us-after-bin.toml",
+        "invalid/integer/us-after-hex.toml",
+        "invalid/integer/us-after-oct.toml",
+    )
+}
+
+/** Missing validation — malformed float literals not rejected */
+data object MissingValidationFloatFormat : KnownFailure {
+    override val issue = 383
+    override val tests = listOf(
+        "invalid/float/exp-dot-02.toml",
+        "invalid/float/exp-dot-03.toml",
+        "invalid/float/leading-dot.toml",
+        "invalid/float/leading-dot-neg.toml",
+        "invalid/float/leading-dot-plus.toml",
+        "invalid/float/leading-zero.toml",
+        "invalid/float/leading-zero-neg.toml",
+        "invalid/float/leading-zero-plus.toml",
+        "invalid/float/nan-capital.toml",
+        "invalid/float/trailing-dot.toml",
+        "invalid/float/trailing-dot-01.toml",
+        "invalid/float/trailing-dot-02.toml",
+        "invalid/float/trailing-dot-min.toml",
+        "invalid/float/trailing-dot-plus.toml",
+    )
+}
+
+/** Missing validation — invalid keys not rejected */
+data object MissingValidationKeys : KnownFailure {
+    override val issue = 383
+    override val tests = listOf(
+        "invalid/key/dot.toml",
+        "invalid/key/dotdot.toml",
+        "invalid/key/dotted-redefine-table-01.toml",
+        "invalid/key/dotted-redefine-table-02.toml",
+        "invalid/key/duplicate-keys-01.toml",
+        "invalid/key/duplicate-keys-02.toml",
+        "invalid/key/duplicate-keys-03.toml",
+        "invalid/key/duplicate-keys-04.toml",
+        "invalid/key/duplicate-keys-05.toml",
+        "invalid/key/duplicate-keys-07.toml",
+        "invalid/key/duplicate-keys-08.toml",
+        "invalid/key/duplicate-keys-09.toml",
+        "invalid/key/multiline-key-01.toml",
+        "invalid/key/multiline-key-02.toml",
+        "invalid/key/multiline-key-03.toml",
+        "invalid/key/multiline-key-04.toml",
+        "invalid/key/partial-quoted.toml",
+        "invalid/key/start-dot.toml",
+    )
+}
+
+/** Missing validation — invalid inline tables not rejected */
+data object MissingValidationInlineTable : KnownFailure {
+    override val issue = 383
+    override val tests = listOf(
+        "invalid/inline-table/duplicate-key-01.toml",
+        "invalid/inline-table/duplicate-key-02.toml",
+        "invalid/inline-table/duplicate-key-03.toml",
+        "invalid/inline-table/duplicate-key-04.toml",
+        "invalid/inline-table/overwrite-01.toml",
+        "invalid/inline-table/overwrite-02.toml",
+        "invalid/inline-table/overwrite-03.toml",
+        "invalid/inline-table/overwrite-04.toml",
+        "invalid/inline-table/overwrite-05.toml",
+        "invalid/inline-table/overwrite-06.toml",
+        "invalid/inline-table/overwrite-07.toml",
+        "invalid/inline-table/overwrite-08.toml",
+        "invalid/inline-table/overwrite-09.toml",
+        "invalid/inline-table/overwrite-10.toml",
+        "invalid/spec-1.0.0/inline-table-2-0.toml",
+        "invalid/spec-1.0.0/inline-table-3-0.toml",
+        "invalid/spec-1.0.0/table-9-0.toml",
+        "invalid/spec-1.0.0/table-9-1.toml",
+    )
+}
+
+/** Missing validation — invalid string escapes not rejected */
+data object MissingValidationStringEscape : KnownFailure {
+    override val issue = 383
+    override val tests = listOf(
+        "invalid/string/bad-escape-03.toml",
+        "invalid/string/bad-uni-esc-06.toml",
+        "invalid/string/bad-uni-esc-ml-06.toml",
+        "invalid/string/multiline-bad-escape-04.toml",
+    )
+}
+
+/** Missing validation — invalid datetimes not rejected */
+data object MissingValidationDatetime : KnownFailure {
+    override val issue = 383
+    override val tests = listOf(
+        "invalid/datetime/offset-minus-no-minute.toml",
+        "invalid/datetime/offset-plus-no-minute.toml",
+        "invalid/datetime/second-trailing-dot.toml",
+        "invalid/local-time/no-secs.toml",
+        "invalid/local-time/trailing-dot.toml",
+        "invalid/local-datetime/no-secs.toml",
+    )
+}
+
+/** Missing validation — invalid arrays not rejected */
+data object MissingValidationArrays : KnownFailure {
+    override val issue = 383
+    override val tests = listOf(
+        "invalid/array/extend-defined-aot.toml",
+        "invalid/array/extending-table.toml",
+        "invalid/array/only-comma-01.toml",
+        "invalid/array/tables-01.toml",
+        "invalid/array/tables-02.toml",
+    )
+}
+
+/**
+ * All known failure groups. Used by [TomlTestSuite] to build the lookup map.
+ */
+val allKnownFailures: List<KnownFailure> = listOf(
+    DatetimeOffsetLoss,
+    FloatRepresentationLoss,
+    DottedKeyExpansion,
+    ArrayOfTablesStructure,
+    KeyNameQuoting,
+    ValidTomlRejected,
+    StackOverflowOnNesting,
+    MultilineStringEscape,
+    MultilineInlineTableCrash,
+    MissingValidationControlChars,
+    MissingValidationEncoding,
+    MissingValidationTableRedefinition,
+    MissingValidationIntegerFormat,
+    MissingValidationFloatFormat,
+    MissingValidationKeys,
+    MissingValidationInlineTable,
+    MissingValidationStringEscape,
+    MissingValidationDatetime,
+    MissingValidationArrays,
+)
+
+/**
+ * Combined map of all known failures: test path → issue URL.
+ * Used by [TomlTestSuite] to skip expected failures and detect fixes.
+ */
+val knownFailuresMap: Map<String, String> by lazy {
+    allKnownFailures.flatMap { failure ->
+        failure.tests.map { it to failure.issueUrl }
+    }.toMap()
+}

--- a/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
+++ b/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
@@ -42,7 +42,6 @@ data object DatetimeOffsetLoss : KnownFailure {
         "valid/comment/everywhere.toml",
         "valid/datetime/milliseconds.toml",
         "valid/datetime/timezone.toml",
-        "valid/spec-1.0.0/offset-date-time-0.toml",
         "valid/spec-example-1.toml",
         "valid/spec-example-1-compact.toml",
     )
@@ -53,7 +52,6 @@ data object FloatRepresentationLoss : KnownFailure {
     override val issue = 376
     override val tests = listOf(
         "valid/float/exponent.toml",
-        "valid/spec-1.0.0/float-0.toml",
     )
 }
 
@@ -91,7 +89,6 @@ data object KeyNameQuoting : KnownFailure {
     override val tests = listOf(
         "valid/key/space.toml",
         "valid/multibyte.toml",
-        "valid/spec-1.0.0/table-3.toml",
         "valid/table/empty-name.toml",
         "valid/table/with-literal-string.toml",
         "valid/table/with-single-quotes.toml",
@@ -113,9 +110,6 @@ data object ValidTomlRejected : KnownFailure {
         "valid/key/escapes.toml",
         "valid/key/quoted-unicode.toml",
         "valid/key/special-chars.toml",
-        "valid/spec-1.0.0/array-0.toml",
-        "valid/spec-1.0.0/float-1.toml",
-        "valid/spec-1.0.0/keys-1.toml",
         "valid/table/names.toml",
         "valid/table/names-with-values.toml",
     )
@@ -333,10 +327,6 @@ data object MissingValidationInlineTable : KnownFailure {
         "invalid/inline-table/overwrite-08.toml",
         "invalid/inline-table/overwrite-09.toml",
         "invalid/inline-table/overwrite-10.toml",
-        "invalid/spec-1.0.0/inline-table-2-0.toml",
-        "invalid/spec-1.0.0/inline-table-3-0.toml",
-        "invalid/spec-1.0.0/table-9-0.toml",
-        "invalid/spec-1.0.0/table-9-1.toml",
     )
 }
 
@@ -358,9 +348,7 @@ data object MissingValidationDatetime : KnownFailure {
         "invalid/datetime/offset-minus-no-minute.toml",
         "invalid/datetime/offset-plus-no-minute.toml",
         "invalid/datetime/second-trailing-dot.toml",
-        "invalid/local-time/no-secs.toml",
         "invalid/local-time/trailing-dot.toml",
-        "invalid/local-datetime/no-secs.toml",
     )
 }
 

--- a/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
+++ b/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
@@ -21,6 +21,9 @@ package com.akuleshov7.ktoml.compliance
  * | Multiline string escape handling | [#382](https://github.com/orchestr7/ktoml/issues/382) |
  * | Multiline inline table crash | [#374](https://github.com/orchestr7/ktoml/issues/374) |
  * | Missing validation (accepts invalid) | [#383](https://github.com/orchestr7/ktoml/issues/383) |
+ * | TOML 1.1 valid features unsupported | [#373](https://github.com/orchestr7/ktoml/issues/373) |
+ *
+ * The suite runs against the **TOML 1.1** file list (`files-toml-1.1.0`), matching the project goal.
  *
  * Related: [#32](https://github.com/orchestr7/ktoml/issues/32) (toml-test integration),
  * [#373](https://github.com/orchestr7/ktoml/issues/373) (TOML 1.1 umbrella)
@@ -146,6 +149,8 @@ data object MultilineInlineTableCrash : KnownFailure {
         "valid/inline-table/array-03.toml",
         "valid/inline-table/key-dotted-07.toml",
         "valid/inline-table/multiline.toml",
+        "valid/inline-table/newline.toml",
+        "valid/inline-table/newline-comment.toml",
     )
 }
 
@@ -160,12 +165,14 @@ data object MissingValidationControlChars : KnownFailure {
         "invalid/control/comment-lf.toml",
         "invalid/control/comment-null.toml",
         "invalid/control/comment-us.toml",
+        "invalid/control/multi-cr.toml",
         "invalid/control/multi-del.toml",
         "invalid/control/multi-lf.toml",
         "invalid/control/multi-null.toml",
         "invalid/control/multi-us.toml",
         "invalid/control/only-ff.toml",
         "invalid/control/only-vt.toml",
+        "invalid/control/rawmulti-cr.toml",
         "invalid/control/rawmulti-del.toml",
         "invalid/control/rawmulti-lf.toml",
         "invalid/control/rawmulti-null.toml",
@@ -371,6 +378,40 @@ data object MissingValidationArrays : KnownFailure {
 }
 
 /**
+ * TOML 1.1 valid features ktoml does not yet support (parser rejects or mis-represents them).
+ * Tracked under the TOML 1.1 umbrella [#373](https://github.com/orchestr7/ktoml/issues/373):
+ * `\x` / `\e` string escapes, seconds-less datetimes, and assorted 1.1 spec examples.
+ */
+data object TomlOneOneValidFeatures : KnownFailure {
+    override val issue = 373
+    override val tests = listOf(
+        "valid/string/hex-escape.toml",
+        "valid/string/escape-esc.toml",
+        "valid/datetime/no-seconds.toml",
+        "valid/spec-1.1.0/common-4.toml",
+        "valid/spec-1.1.0/common-12.toml",
+        "valid/spec-1.1.0/common-23.toml",
+        "valid/spec-1.1.0/common-24.toml",
+        "valid/spec-1.1.0/common-27.toml",
+        "valid/spec-1.1.0/common-29.toml",
+        "valid/spec-1.1.0/common-35.toml",
+        "valid/spec-1.1.0/common-40.toml",
+        "valid/spec-1.1.0/common-47.toml",
+    )
+}
+
+/** Missing validation — TOML 1.1 invalid spec examples that ktoml accepts. Tracked under #373/#383. */
+data object TomlOneOneMissingValidation : KnownFailure {
+    override val issue = 373
+    override val tests = listOf(
+        "invalid/spec-1.1.0/common-46-0.toml",
+        "invalid/spec-1.1.0/common-46-1.toml",
+        "invalid/spec-1.1.0/common-49-0.toml",
+        "invalid/spec-1.1.0/common-50-0.toml",
+    )
+}
+
+/**
  * All known failure groups. Used by [TomlTestSuite] to build the lookup map.
  */
 val allKnownFailures: List<KnownFailure> = listOf(
@@ -393,6 +434,8 @@ val allKnownFailures: List<KnownFailure> = listOf(
     MissingValidationStringEscape,
     MissingValidationDatetime,
     MissingValidationArrays,
+    TomlOneOneValidFeatures,
+    TomlOneOneMissingValidation,
 )
 
 /**

--- a/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
+++ b/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
@@ -103,7 +103,6 @@ data object ValidTomlRejected : KnownFailure {
     override val issue = 380
     override val tests = listOf(
         "valid/array/mixed-string-table.toml",
-        "valid/array/table-array-string-backslash.toml",
         "valid/datetime/edge.toml",
         "valid/datetime/leap-year.toml",
         "valid/datetime/local.toml",

--- a/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestConverter.kt
+++ b/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestConverter.kt
@@ -1,0 +1,130 @@
+package com.akuleshov7.ktoml.compliance
+
+import com.akuleshov7.ktoml.tree.nodes.*
+import com.akuleshov7.ktoml.tree.nodes.pairs.values.*
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.serialization.json.*
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/**
+ * Converts a ktoml AST (rooted at [TomlFile]) into the toml-test "tagged JSON" format.
+ *
+ * Spec: https://github.com/toml-lang/toml-test#tagged-json
+ *
+ * Every TOML value becomes `{"type": "<type>", "value": "<string>"}`.
+ * Tables become plain JSON objects. Arrays become JSON arrays.
+ */
+object TomlTestConverter {
+
+    fun toJson(root: TomlFile): JsonObject = childrenToJson(root.children)
+
+    private fun tableToJson(table: TomlTable): JsonElement = when (table.type) {
+        TableType.PRIMITIVE -> childrenToJson(table.children)
+        TableType.ARRAY -> {
+            val elements = table.children
+                .filterIsInstance<TomlArrayOfTablesElement>()
+                .map { childrenToJson(it.children) }
+            JsonArray(elements)
+        }
+    }
+
+    // -- value dispatch --
+
+    private fun valueToJson(value: TomlValue): JsonElement = when (value) {
+        is TomlBasicString -> tagged("string", value.content as String)
+        is TomlLiteralString -> tagged("string", value.content as String)
+        is TomlLong -> tagged("integer", (value.content as Long).toString())
+        is TomlUnsignedLong -> tagged("integer", (value.content as ULong).toString())
+        is TomlDouble -> tagged("float", formatFloat(value.content as Double))
+        is TomlBoolean -> tagged("bool", (value.content as Boolean).toString())
+        is TomlDateTime -> datetimeToJson(value.content)
+        is TomlNull -> JsonNull
+        is TomlArray -> arrayToJson(value)
+    }
+
+    // -- arrays --
+
+    @Suppress("UNCHECKED_CAST")
+    private fun arrayToJson(arr: TomlArray): JsonArray {
+        val items = (arr.content as List<Any>).map { element ->
+            when (element) {
+                is TomlValue -> valueToJson(element)
+                is TomlArray -> arrayToJson(element)
+                else -> error("Unknown array element type: ${element::class.simpleName}")
+            }
+        }
+        return JsonArray(items)
+    }
+
+    // -- datetime --
+
+    @OptIn(ExperimentalTime::class)
+    private fun datetimeToJson(content: Any): JsonElement = when (content) {
+        is Instant -> tagged("datetime", content.toString())
+        is LocalDateTime -> tagged("datetime-local", formatLocalDateTime(content))
+        is LocalDate -> tagged("date-local", content.toString())
+        is LocalTime -> tagged("time-local", formatLocalTime(content))
+        else -> error("Unknown datetime type: ${content::class.simpleName}")
+    }
+
+    // LocalTime.toString() drops seconds when they are 0 (e.g. "17:45" instead of "17:45:00").
+    // toml-test always expects seconds.
+    private fun formatLocalTime(t: LocalTime): String {
+        val base = "%02d:%02d:%02d".format(t.hour, t.minute, t.second)
+        return if (t.nanosecond != 0) {
+            // Strip trailing zeros from fractional seconds
+            val frac = "%09d".format(t.nanosecond).trimEnd('0')
+            "$base.$frac"
+        } else {
+            base
+        }
+    }
+
+    private fun formatLocalDateTime(dt: LocalDateTime): String =
+        "${dt.date}T${formatLocalTime(dt.time)}"
+
+    // -- helpers --
+
+    private fun childrenToJson(children: List<TomlNode>): JsonObject = buildJsonObject {
+        for (child in children) {
+            when (child) {
+                is TomlStubEmptyNode -> {} // skip
+                is TomlTable -> put(child.name, tableToJson(child))
+                is TomlKeyValuePrimitive -> put(child.name, valueToJson(child.value))
+                is TomlKeyValueArray -> put(child.name, valueToJson(child.value))
+                is TomlInlineTable -> put(child.name, childrenToJson(child.tomlKeyValues))
+                is TomlArrayOfTablesElement -> {
+                    // Shouldn't normally appear as direct child — handled via tableToJson
+                    val obj = childrenToJson(child.children)
+                    obj.forEach { (k, v) -> put(k, v) }
+                }
+                else -> error("Unhandled child type: ${child::class.simpleName}")
+            }
+        }
+    }
+
+    private fun tagged(type: String, value: String): JsonObject = buildJsonObject {
+        put("type", type)
+        put("value", value)
+    }
+
+    private fun formatFloat(d: Double): String = when {
+        d.isNaN() -> "nan"
+        d.isInfinite() -> if (d > 0) "inf" else "-inf"
+        // Negative zero: Double.toBits() distinguishes +0.0 from -0.0
+        d == 0.0 -> if (d.toBits() == (-0.0).toBits()) "-0" else "0"
+        else -> {
+            // BigDecimal.toString() uses scientific notation for large/small exponents,
+            // plain notation otherwise — matching toml-test expectations.
+            d.toBigDecimal().stripTrailingZeros().toString()
+                .lowercase()
+                // Pad single-digit exponents: e+6 → e+06, e-4 → e-04
+                .replace(Regex("e([+-])(\\d)$")) { m ->
+                    "e${m.groupValues[1]}0${m.groupValues[2]}"
+                }
+        }
+    }
+}

--- a/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestSuite.kt
+++ b/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestSuite.kt
@@ -4,6 +4,7 @@ import com.akuleshov7.ktoml.TomlInputConfig
 import com.akuleshov7.ktoml.parsers.TomlParser
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -12,6 +13,7 @@ import java.io.File
 import java.util.stream.Stream
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.test.assertTrue
 import kotlin.test.fail
 
 /**
@@ -65,8 +67,12 @@ class TomlTestSuite {
     fun `valid TOML parses correctly`(testPath: String) {
         val tomlFile = testDir.resolve(testPath)
         val jsonFile = testDir.resolve(testPath.replace(".toml", ".json"))
-        assumeTrue(tomlFile.exists(), "TOML file missing: $testPath")
-        assumeTrue(jsonFile.exists(), "Expected JSON missing for: $testPath")
+        assertTrue(tomlFile.exists(), missingFileMessage(testPath))
+        assertTrue(
+            jsonFile.exists(),
+            "Misconfiguration: expected JSON is listed but missing on disk: " +
+                testPath.replace(".toml", ".json"),
+        )
 
         val issueUrl = knownFailuresMap[testPath]
 
@@ -92,7 +98,7 @@ class TomlTestSuite {
     @MethodSource("invalidTestCases")
     fun `invalid TOML is rejected`(testPath: String) {
         val tomlFile = testDir.resolve(testPath)
-        assumeTrue(tomlFile.exists(), "TOML file missing: $testPath")
+        assertTrue(tomlFile.exists(), missingFileMessage(testPath))
 
         val issueUrl = knownFailuresMap[testPath]
 
@@ -112,5 +118,25 @@ class TomlTestSuite {
                 result.getOrThrow()
         }
     }
+
+    /**
+     * Guards against stale baseline entries: a path listed in [knownFailuresMap] but absent from the
+     * loaded toml-test file list is never executed, so it can neither XPASS nor fail — it just lingers
+     * silently and gives a false sense of coverage. Fail loudly so it gets removed.
+     */
+    @Test
+    fun `baseline references only tests present in the file list`() {
+        val listed = loadFileList().toSet()
+        val stale = knownFailuresMap.keys.filterNot { it in listed }
+        assertTrue(
+            stale.isEmpty(),
+            "Stale baseline entries — listed in TomlTestBaseline.kt but not in the loaded toml-test " +
+                "file list, so they never run. Remove them: $stale",
+        )
+    }
+
+    private fun missingFileMessage(testPath: String) =
+        "Misconfiguration: '$testPath' is in the toml-test file list but missing on disk. " +
+            "The toml-test submodule is incomplete — run: git submodule update --init --recursive"
 }
 

--- a/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestSuite.kt
+++ b/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestSuite.kt
@@ -1,0 +1,116 @@
+package com.akuleshov7.ktoml.compliance
+
+import com.akuleshov7.ktoml.TomlInputConfig
+import com.akuleshov7.ktoml.parsers.TomlParser
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.io.File
+import java.util.stream.Stream
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.fail
+
+/**
+ * Runs the [toml-lang/toml-test](https://github.com/toml-lang/toml-test) compliance suite
+ * against ktoml's parser (TOML 1.0 file list).
+ *
+ * - **Valid tests:** parse TOML → convert AST to tagged JSON via [TomlTestConverter] → compare
+ *   with expected JSON from the test suite.
+ * - **Invalid tests:** verify that parsing throws an exception.
+ *
+ * Known failures are declared in [TomlTestBaseline.kt]. Every test is still executed:
+ * - If a known failure **still fails** → test is skipped (expected behavior).
+ * - If a known failure **now passes** → test **FAILS** with an XPASS message prompting
+ *   removal from the baseline. This ensures bug fixes are detected automatically.
+ *
+ * ## Running
+ *
+ * ```
+ * ./gradlew :ktoml-core:jvmTest --tests "com.akuleshov7.ktoml.compliance.TomlTestSuite"
+ * ```
+ *
+ * Requires the `toml-test` git submodule: `git submodule update --init`
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TomlTestSuite {
+    private val testDir = File("../toml-test/tests")
+
+    private fun loadFileList(version: String = "1.0.0"): List<String> {
+        val listFile = testDir.resolve("files-toml-$version")
+        require(listFile.exists()) {
+            "toml-test file list not found at ${listFile.absolutePath}. " +
+                "Did you initialize the git submodule? Run: git submodule update --init"
+        }
+        return listFile.readLines().filter { it.isNotBlank() }
+    }
+
+    fun validTestCases(): Stream<Arguments> =
+        loadFileList()
+            .filter { it.startsWith("valid/") && it.endsWith(".toml") }
+            .map { Arguments.of(it) }
+            .stream()
+
+    fun invalidTestCases(): Stream<Arguments> =
+        loadFileList()
+            .filter { it.startsWith("invalid/") && it.endsWith(".toml") }
+            .map { Arguments.of(it) }
+            .stream()
+
+    @ParameterizedTest(name = "valid: {0}")
+    @MethodSource("validTestCases")
+    fun `valid TOML parses correctly`(testPath: String) {
+        val tomlFile = testDir.resolve(testPath)
+        val jsonFile = testDir.resolve(testPath.replace(".toml", ".json"))
+        assumeTrue(tomlFile.exists(), "TOML file missing: $testPath")
+        assumeTrue(jsonFile.exists(), "Expected JSON missing for: $testPath")
+
+        val issueUrl = knownFailuresMap[testPath]
+
+        val result = runCatching {
+            val tomlInput = tomlFile.readText()
+            val expectedJson = Json.parseToJsonElement(jsonFile.readText())
+            val tree = TomlParser(TomlInputConfig.compliant()).parseString(tomlInput)
+            val actualJson = TomlTestConverter.toJson(tree)
+            assertEquals(expectedJson, actualJson, "Mismatch for $testPath")
+        }
+
+        when {
+            result.isSuccess && issueUrl != null ->
+                fail("XPASS: '$testPath' now passes! Remove it from knownFailures. (Was: $issueUrl)")
+            result.isFailure && issueUrl != null ->
+                assumeTrue(false, "Known failure: $testPath — $issueUrl")
+            result.isFailure ->
+                result.getOrThrow()
+        }
+    }
+
+    @ParameterizedTest(name = "invalid: {0}")
+    @MethodSource("invalidTestCases")
+    fun `invalid TOML is rejected`(testPath: String) {
+        val tomlFile = testDir.resolve(testPath)
+        assumeTrue(tomlFile.exists(), "TOML file missing: $testPath")
+
+        val issueUrl = knownFailuresMap[testPath]
+
+        val result = runCatching {
+            val tomlInput = tomlFile.readText()
+            assertFails("Expected parse failure for $testPath") {
+                TomlParser(TomlInputConfig.compliant()).parseString(tomlInput)
+            }
+        }
+
+        when {
+            result.isSuccess && issueUrl != null ->
+                fail("XPASS: '$testPath' now passes! Remove it from knownFailures. (Was: $issueUrl)")
+            result.isFailure && issueUrl != null ->
+                assumeTrue(false, "Known failure: $testPath — $issueUrl")
+            result.isFailure ->
+                result.getOrThrow()
+        }
+    }
+}
+

--- a/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestSuite.kt
+++ b/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestSuite.kt
@@ -16,7 +16,7 @@ import kotlin.test.fail
 
 /**
  * Runs the [toml-lang/toml-test](https://github.com/toml-lang/toml-test) compliance suite
- * against ktoml's parser (TOML 1.0 file list).
+ * against ktoml's parser (TOML 1.1 file list — matching the project goal).
  *
  * - **Valid tests:** parse TOML → convert AST to tagged JSON via [TomlTestConverter] → compare
  *   with expected JSON from the test suite.
@@ -39,7 +39,7 @@ import kotlin.test.fail
 class TomlTestSuite {
     private val testDir = File("../toml-test/tests")
 
-    private fun loadFileList(version: String = "1.0.0"): List<String> {
+    private fun loadFileList(version: String = "1.1.0"): List<String> {
         val listFile = testDir.resolve("files-toml-$version")
         require(listFile.exists()) {
             "toml-test file list not found at ${listFile.absolutePath}. " +


### PR DESCRIPTION
## Summary

Adds the [toml-lang/toml-test](https://github.com/toml-lang/toml-test) official TOML 1.0 compliance suite as a git submodule with a JVM parameterized test runner.

Runs as part of the standard `:ktoml-core:jvmTest` task — no special setup required.

## What's included

- **`toml-test/`** — git submodule pinned to `ce08da1`
- **`TomlTestConverter.kt`** — AST → tagged JSON converter (the format toml-test expects)
- **`TomlTestSuite.kt`** — parameterized test runner with xfail pattern
- **`TomlTestBaseline.kt`** — self-documenting baseline of all known failures, grouped by category with upstream issue links
- **README** section pointing to the baseline source

## Results

- ~679 test cases from the suite
- 474 passing
- 205 known failures tracked as xfail (test fails if a "known failure" starts passing, forcing baseline cleanup)

## Filed issues

Each failure category is tracked with a dedicated issue:

| Issue | Category |
|-------|----------|
| #375 | Offset datetime loses timezone info |
| #376 | Float formatting loses representation |
| #377 | Dotted key expansion incorrect |
| #378 | Array-of-tables structure edge cases |
| #379 | Key names not properly unquoted |
| #380 | Parser rejects valid TOML |
| #381 | Stack overflow on deep nesting |
| #382 | Multiline string escape handling |
| #383 | Missing validation for invalid TOML |
| #374 | Multiline inline tables crash |

Meta-issue: #32