### PR TITLE
fix: parse deeply nested inline tables and nested arrays of inline tables

### DIFF
--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/tables/TomlInlineTable.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/tables/TomlInlineTable.kt
@@ -73,13 +73,35 @@ public class TomlInlineTable internal constructor(
                     keyValue.returnTable(tomlFileHead, tomlTable)
                 )
 
-                keyValue is TomlArrayOfTablesElement -> tomlTable.appendChild(keyValue)
+                keyValue is TomlArrayOfTablesElement -> {
+                    tomlTable.appendChild(keyValue)
+                    keyValue.expandNestedInlineArraysOfTables(tomlFileHead)
+                }
 
                 // otherwise, it should simply append the keyValue to the parent
                 else -> tomlTable.appendChild(keyValue)
             }
         }
         return tomlTable
+    }
+
+    /**
+     * Expand inline arrays of tables nested inside this array-of-tables element (e.g. the
+     * `children = [{ ... }]` in `kids = [{ name = "x", children = [{ ... }] }]`) into proper
+     * `[[parent.child]]` tables nested under the element. Otherwise they would be left as raw
+     * inline nodes and fail to decode as lists - see issues #360 and #29.
+     */
+    private fun TomlArrayOfTablesElement.expandNestedInlineArraysOfTables(tomlFileHead: TomlFile) {
+        children
+            .filterIsInstance<TomlInlineTable>()
+            .filter { it.isInlineArrayOfTables() }
+            .toList()
+            .forEach { nested ->
+                children.remove(nested)
+                // the parent table is not in the file tree yet, so we attach the expanded
+                // table directly to the element instead of going through insertTableToTree
+                appendChild(nested.returnTable(tomlFileHead, this))
+            }
     }
 
     public override fun write(
@@ -179,7 +201,7 @@ public class TomlInlineTable internal constructor(
                         )
                     }
                 }
-                .splitInlineTableToKeyValue(config.allowEscapedQuotesInLiteralStrings, lineNo)
+                .splitInlineTableToKeyValue(config.allowEscapedQuotesInLiteralStrings)
                 .map {
                     it.parseTomlKeyValue(lineNo, comments = emptyList(), inlineComment = "", config)
                 }
@@ -210,8 +232,9 @@ public class TomlInlineTable internal constructor(
         }
 
         /**
-         *  Split by "}," - but skip all whitespaces between '}' and ','
-         *  Also ignore characters inside strings and keep closing '}' in each value
+         *  Split an array of inline tables ([ {..}, {..} ]) into the strings of its
+         *  table elements. Splitting happens only on top-level commas: commas nested
+         *  inside tables { }, arrays [ ] or quotes " "/' ' are kept as part of the element.
          */
         @Suppress("TOO_LONG_FUNCTION")
         private fun String.splitInlineArrayOfTables(): List<String> {
@@ -221,44 +244,37 @@ public class TomlInlineTable internal constructor(
             val result: MutableList<String> = mutableListOf()
             val current = StringBuilder()
             var openQuoteChar: Char? = null
-            var isCurlyBracesFound = false
+            var bracketDepth = 0
 
             clearedString.forEach { currentChar ->
-                // currentChar is inside quotes, so just add it
-                if (openQuoteChar != null && currentChar != openQuoteChar) {
-                    current.append(currentChar)
-                    return@forEach
-                }
-
-                when (currentChar) {
-                    openQuoteChar -> {
-                        openQuoteChar = null
+                when {
+                    // currentChar is inside quotes, so just add it
+                    openQuoteChar != null -> {
+                        if (currentChar == openQuoteChar) {
+                            openQuoteChar = null
+                        }
                         current.append(currentChar)
                     }
-
-                    '\"', '\'' -> {
+                    currentChar == '\"' || currentChar == '\'' -> {
                         openQuoteChar = currentChar
                         current.append(currentChar)
                     }
-
-                    '}' -> {
-                        isCurlyBracesFound = true
+                    currentChar == '{' || currentChar == '[' -> {
+                        bracketDepth++
                         current.append(currentChar)
                     }
-
-                    ',' -> if (isCurlyBracesFound) {
-                        // comma between inline tables
-                        isCurlyBracesFound = false
-                        result.add(current.toString().trim())
+                    currentChar == '}' || currentChar == ']' -> {
+                        bracketDepth--
+                        current.append(currentChar)
+                    }
+                    // a top-level comma separates two inline tables in the array
+                    currentChar == ',' && bracketDepth == 0 -> {
+                        if (current.isNotBlank()) {
+                            result.add(current.toString().trim())
+                        }
                         current.clear()
-                    } else {
-                        // comma between inline table values
-                        current.append(currentChar)
                     }
-
-                    else -> if (!isCurlyBracesFound) {
-                        current.append(currentChar)
-                    }
+                    else -> current.append(currentChar)
                 }
             }
 
@@ -271,65 +287,38 @@ public class TomlInlineTable internal constructor(
 
         /**
          * That's basically split(",") function, but we ignore all commas inside arrays [ ],
-         * nested tables { } and quotes " "/' '
+         * nested tables { } and quotes " "/' '. The bracket depth is tracked so that inline
+         * tables nested to any depth are split correctly (see issues #29 and #360).
          */
         @Suppress("TOO_LONG_FUNCTION")
         private fun String.splitInlineTableToKeyValue(
             allowEscapedQuotesInLiteralStrings: Boolean,
-            lineNo: Int,
         ): List<String> {
             val clearedString = this.replaceEscaped(allowEscapedQuotesInLiteralStrings)
             val keyValueList: MutableList<String> = mutableListOf()
-            var isLastAdded = false
             var currentQuoteChar: Char? = null
+            var bracketDepth = 0
             var prevIdx = 0
-            var curIdx = 0
 
-            while (curIdx < clearedString.length) {
-                val ch = clearedString[curIdx]
-                if (ch == ',' && currentQuoteChar == null) {
-                    keyValueList.add(this.substring(prevIdx, curIdx).trim())
-                    prevIdx = curIdx + 1
-                } else if (currentQuoteChar == null && (ch == '[' || ch == '{')) {
-                    val closeBracketIdx = this.indexOfNextOutsideQuotes(
-                        allowEscapedQuotesInLiteralStrings = allowEscapedQuotesInLiteralStrings,
-                        searchChar = getCloseBracket(ch, lineNo),
-                        startIndex = curIdx,
-                    )
-                    keyValueList.add(this.substring(prevIdx, closeBracketIdx + 1).trim())
-                    val nextCommaIdx = this.indexOfNextOutsideQuotes(
-                        allowEscapedQuotesInLiteralStrings = allowEscapedQuotesInLiteralStrings,
-                        searchChar = ',',
-                        startIndex = closeBracketIdx,
-                    )
-                    if (nextCommaIdx == -1) {
-                        isLastAdded = true
-                        break
-                    }
-                    prevIdx = nextCommaIdx + 1
-                    curIdx = nextCommaIdx + 1
-                } else if (ch == '\'' || ch == '\"') {
-                    if (currentQuoteChar == null) {
-                        currentQuoteChar = ch
-                    } else if (currentQuoteChar == ch) {
+            clearedString.forEachIndexed { idx, ch ->
+                when {
+                    // inside a quoted string only the matching closing quote is meaningful
+                    currentQuoteChar != null -> if (ch == currentQuoteChar) {
                         currentQuoteChar = null
                     }
+                    ch == '\'' || ch == '\"' -> currentQuoteChar = ch
+                    ch == '[' || ch == '{' -> bracketDepth++
+                    ch == ']' || ch == '}' -> bracketDepth--
+                    // only a top-level comma (not nested inside [] or {}) separates key-value pairs
+                    ch == ',' && bracketDepth == 0 -> {
+                        keyValueList.add(this.substring(prevIdx, idx).trim())
+                        prevIdx = idx + 1
+                    }
                 }
-                curIdx++
             }
-            if (!isLastAdded) {
-                keyValueList.add(this.substring(prevIdx, this.length).trim())
-            }
+            keyValueList.add(this.substring(prevIdx).trim())
 
             return keyValueList
-        }
-
-        private fun getCloseBracket(openBracket: Char, lineNo: Int): Char = if (openBracket == '[') {
-            ']'
-        } else if (openBracket == '{') {
-            '}'
-        } else {
-            throw ParseException("Invalid open bracket: $openBracket, should never happen", lineNo)
         }
     }
 }

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/tables/NestedInlineTableTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/tables/NestedInlineTableTest.kt
@@ -1,0 +1,210 @@
+package com.akuleshov7.ktoml.decoders.tables
+
+import com.akuleshov7.ktoml.Toml
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression tests for crashes on deeply nested inline tables and on arrays of
+ * inline tables that themselves contain nested arrays/tables.
+ *
+ * - https://github.com/orchestr7/ktoml/issues/360 (inline-table cases)
+ * - https://github.com/gildor/ktoml/issues/29
+ *
+ * Before the fix, the inline-table splitters did not track bracket-nesting
+ * depth, so depth 3+ inline tables computed a negative index and crashed in
+ * `indexOfNextOutsideQuotes` (`drop(-1)`), and arrays of inline tables with a
+ * nested array dropped a closing `]` and crashed with a
+ * `StringIndexOutOfBoundsException`.
+ */
+class NestedInlineTableTest {
+    @Serializable
+    data class Depth3Inner(val a: Int)
+
+    @Serializable
+    data class Depth3Middle(val a: Depth3Inner)
+
+    @Serializable
+    data class Depth3Outer(val a: Depth3Middle)
+
+    @Serializable
+    data class Depth3Root(val x: Depth3Outer)
+
+    @Test
+    fun decodeInlineTableNestedThreeLevels() {
+        // x = { a = { a = { a = 1 } } } — valid TOML 1.0, crashed before the fix
+        val test = "x = { a = { a = { a = 1 } } }"
+
+        assertEquals(
+            Depth3Root(Depth3Outer(Depth3Middle(Depth3Inner(1)))),
+            Toml.decodeFromString<Depth3Root>(test),
+        )
+    }
+
+    @Serializable
+    data class Depth4Inner(val a: Int)
+
+    @Serializable
+    data class Depth4L3(val a: Depth4Inner)
+
+    @Serializable
+    data class Depth4L2(val a: Depth4L3)
+
+    @Serializable
+    data class Depth4L1(val a: Depth4L2)
+
+    @Serializable
+    data class Depth4Root(val x: Depth4L1)
+
+    @Test
+    fun decodeInlineTableNestedFourLevels() {
+        val test = "x = { a = { a = { a = { a = 1 } } } }"
+
+        assertEquals(
+            Depth4Root(Depth4L1(Depth4L2(Depth4L3(Depth4Inner(1))))),
+            Toml.decodeFromString<Depth4Root>(test),
+        )
+    }
+
+    @Test
+    fun decodeInlineTableNestedWithSiblings() {
+        // sibling keys around the deeply nested value must still split correctly
+        @Serializable
+        data class Inner(val a: Int)
+
+        @Serializable
+        data class Middle(val a: Inner, val b: Int)
+
+        @Serializable
+        data class Outer(val nested: Middle, val flag: Boolean)
+
+        val test = "out = { nested = { a = { a = 1 }, b = 2 }, flag = true }"
+
+        @Serializable
+        data class Root(val out: Outer)
+
+        assertEquals(
+            Root(Outer(Middle(Inner(1), 2), true)),
+            Toml.decodeFromString<Root>(test),
+        )
+    }
+
+    @Serializable
+    data class Child(val name: String)
+
+    @Serializable
+    data class Parent(val name: String, val children: List<Child>? = null)
+
+    @Serializable
+    data class Grandparent(val name: String, val kids: List<Parent>)
+
+    @Test
+    fun decodeArrayOfInlineTablesWithNestedArray() {
+        // https://github.com/orchestr7/ktoml/issues/360 — crashed with
+        // StringIndexOutOfBoundsException before the fix
+        val test =
+            """
+            |name = "the-grandparent"
+            |kids = [{ name = "number-one-parent", children = [{ name = "some-kid" }] }]
+            """.trimMargin()
+
+        assertEquals(
+            Grandparent(
+                name = "the-grandparent",
+                kids = listOf(Parent("number-one-parent", listOf(Child("some-kid")))),
+            ),
+            Toml.decodeFromString<Grandparent>(test),
+        )
+    }
+
+    @Test
+    fun decodeArrayOfInlineTablesWithNestedArrayTwoElements() {
+        // https://github.com/orchestr7/ktoml/issues/360 — second crashing case;
+        // each parent must keep its own child, not have them merged together
+        val test =
+            """
+            |name = "the-grandparent"
+            |kids = [{ name = "number-one-parent", children = [{ name = "some-kid" }] }, { name = "number-two-parent", children = [{ name = "another-kid" }] }]
+            """.trimMargin()
+
+        assertEquals(
+            Grandparent(
+                name = "the-grandparent",
+                kids = listOf(
+                    Parent("number-one-parent", listOf(Child("some-kid"))),
+                    Parent("number-two-parent", listOf(Child("another-kid"))),
+                ),
+            ),
+            Toml.decodeFromString<Grandparent>(test),
+        )
+    }
+
+    @Test
+    fun decodeArrayOfInlineTablesMultipleChildrenPerParent() {
+        val test =
+            """
+            |name = "the-grandparent"
+            |kids = [{ name = "p1", children = [{ name = "a" }, { name = "b" }] }]
+            """.trimMargin()
+
+        assertEquals(
+            Grandparent(
+                name = "the-grandparent",
+                kids = listOf(Parent("p1", listOf(Child("a"), Child("b")))),
+            ),
+            Toml.decodeFromString<Grandparent>(test),
+        )
+    }
+
+    @Test
+    fun decodeChildlessArrayOfInlineTablesStillWorks() {
+        // these cases already worked before the fix; lock them in against regressions
+        val nullChildren =
+            """
+            |name = "g"
+            |kids = [{ name = "p1" }]
+            """.trimMargin()
+        val emptyChildren =
+            """
+            |name = "g"
+            |kids = [{ name = "p1", children = [] }]
+            """.trimMargin()
+
+        assertEquals(
+            Grandparent("g", listOf(Parent("p1", children = null))),
+            Toml.decodeFromString<Grandparent>(nullChildren),
+        )
+        assertEquals(
+            Grandparent("g", listOf(Parent("p1", children = emptyList()))),
+            Toml.decodeFromString<Grandparent>(emptyChildren),
+        )
+    }
+
+    @Serializable
+    data class Lvl3(val name: String)
+
+    @Serializable
+    data class Lvl2(val name: String, val items: List<Lvl3>? = null)
+
+    @Serializable
+    data class Lvl1(val name: String, val items: List<Lvl2>? = null)
+
+    @Serializable
+    data class Lvl0(val name: String, val items: List<Lvl1>)
+
+    @Test
+    fun decodeArrayOfInlineTablesNestedThreeLevels() {
+        val test =
+            """
+            |name = "root"
+            |items = [{ name = "a", items = [{ name = "b", items = [{ name = "c" }] }] }]
+            """.trimMargin()
+
+        assertEquals(
+            Lvl0("root", listOf(Lvl1("a", listOf(Lvl2("b", listOf(Lvl3("c"))))))),
+            Toml.decodeFromString<Lvl0>(test),
+        )
+    }
+}


### PR DESCRIPTION
Two related inline-table parser crashes, both reported in #360:

1. **Inline tables nested 3+ levels deep crash.** `x = { a = { a = { a = 1 } } }`
   — valid TOML 1.0 — throws `IllegalArgumentException` (from `drop(-1)`).
   Depth 1–2 worked.
2. **Arrays of inline tables containing a nested array crash.**
   `kids = [{ name = "p", children = [{ name = "c" }] }]` throws
   `StringIndexOutOfBoundsException` (the `Range [27, 0) out of bounds` from #360).
3. Once the crash is avoided, such a nested array of inline tables still decoded
   **incorrectly**, because it was left as a raw inline node instead of an
   array-of-tables.

## Root cause

`splitInlineTableToKeyValue` and `splitInlineArrayOfTables` located a closing
bracket by searching for the *first* `}` / `]` via `indexOfNextOutsideQuotes`,
ignoring nesting. At depth 3+ this matched the wrong (innermost) bracket,
produced malformed substrings, and eventually passed a negative `startIndex`
into `indexOfNextOutsideQuotes`, where `drop(startIndex)` throws. The
`isCurlyBracesFound` flag in `splitInlineArrayOfTables` likewise dropped the `]`
that closes a nested array.

## Fix

- Rewrite both splitters to split only on **top-level commas**, tracking quote
  state and bracket depth, so any nesting depth is handled correctly. Removes the
  now-unused `getCloseBracket`.
- `returnTable` now expands an inline array of tables nested inside an
  array-of-tables element into a proper `[[parent.child]]` table nested under the
  element, so it decodes as a list (matching the `[[kids]]` / `[[kids.children]]`
  form).