### PR TITLE
fix: keep each array-of-tables element's inline nested arrays under its own element

### DIFF
--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/TomlParser.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/TomlParser.kt
@@ -119,8 +119,16 @@ public value class TomlParser(private val config: TomlInputConfig) {
 
                         keyValue is TomlInlineTable ->
                             // in case of inline tables (a = { b = "c" }) we need to create a new parental table and
-                            // recursively process all inner nested tables (including inline and dotted)
-                            tomlFileHead.insertTableToTree(keyValue.returnTable(tomlFileHead, currentParentalNode))
+                            // recursively process all inner nested tables (including inline and dotted).
+                            // latestCreatedBucket must be threaded through here exactly like for an
+                            // explicit [[array.of.tables]] section above: an inline array of tables
+                            // (children = [{ .. }]) expands to an [[array.children]] fragment, and without
+                            // the bucket the tree builder would re-use the first element's fragment for every
+                            // element instead of creating a fresh one under the current element - see #31.
+                            tomlFileHead.insertTableToTree(
+                                keyValue.returnTable(tomlFileHead, currentParentalNode),
+                                latestCreatedBucket
+                            )
 
                         // otherwise, it should simply append the keyValue to the parent
                         else -> currentParentalNode.appendChild(keyValue)

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/tables/ArrayOfTablesWrongParentTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/tables/ArrayOfTablesWrongParentTest.kt
@@ -1,0 +1,84 @@
+package com.akuleshov7.ktoml.decoders.tables
+
+import com.akuleshov7.ktoml.Toml
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression test for https://github.com/gildor/ktoml/issues/31.
+ *
+ * When repeated `[[a]]` array-of-tables sections each contain an inline array of tables
+ * (`children = [{ ... }]`), the children of the second and later `[[a]]` elements were wrongly
+ * attached to the **first** element: an inline array of tables expands to a `[[a.children]]`
+ * fragment, and the tree builder re-used the first element's `children` bucket instead of
+ * creating a fresh one under the current element.
+ *
+ * The equivalent pure form (`[[kids]]` + `[[kids.children]]`) already decoded correctly; this
+ * locks in that the inline form behaves the same.
+ */
+class ArrayOfTablesWrongParentTest {
+    @Serializable
+    data class Kid(val name: String)
+
+    @Serializable
+    data class Parent(val name: String, val children: List<Kid>? = null)
+
+    @Serializable
+    data class Root(val name: String, val kids: List<Parent>)
+
+    @Test
+    fun eachArrayOfTablesElementKeepsItsOwnInlineChildren() {
+        val toml = """
+            name = "g"
+            [[kids]]
+            name = "p1"
+            children = [{ name = "a" }]
+            [[kids]]
+            name = "p2"
+            children = [{ name = "b" }]
+        """.trimIndent()
+
+        assertEquals(
+            Root(
+                name = "g",
+                kids = listOf(
+                    Parent("p1", listOf(Kid("a"))),
+                    Parent("p2", listOf(Kid("b"))),
+                ),
+            ),
+            Toml.decodeFromString<Root>(toml),
+        )
+    }
+
+    @Test
+    fun inlineChildrenMatchPureNestedArrayOfTables() {
+        val inlineForm = """
+            name = "g"
+            [[kids]]
+            name = "p1"
+            children = [{ name = "a" }]
+            [[kids]]
+            name = "p2"
+            children = [{ name = "b" }]
+        """.trimIndent()
+
+        val pureForm = """
+            name = "g"
+            [[kids]]
+            name = "p1"
+            [[kids.children]]
+            name = "a"
+            [[kids]]
+            name = "p2"
+            [[kids.children]]
+            name = "b"
+        """.trimIndent()
+
+        assertEquals(
+            Toml.decodeFromString<Root>(pureForm),
+            Toml.decodeFromString<Root>(inlineForm),
+        )
+    }
+}


### PR DESCRIPTION
## Problem

When repeated `[[a]]` array-of-tables sections each contain an **inline** array of tables (`children = [{ ... }]`), the children of the second and later `[[a]]` elements were attached to the **first** element.

```toml
name = "g"
[[kids]]
name = "p1"
children = [{ name = "a" }]
[[kids]]
name = "p2"
children = [{ name = "b" }]
```

decoded to `kids = [p1(children=[a, b]), p2(children=null)]` instead of the expected `[p1(children=[a]), p2(children=[b])]`.

The pure section form (`[[kids]]` + `[[kids.children]]`) already decoded correctly — only the inline form was broken.

## Root cause

An inline array of tables expands (via `TomlInlineTable.returnTable`) into an `[[a.children]]` table fragment, which is inserted with `TomlNode.insertTableToTree`. That insertion uses `latestCreatedBucket` to decide whether a matching `children` fragment found under an existing array element should be **reused**, or whether a **fresh** one must be created under the current element (the `freeBucket == latestCreatedBucket` check in `insertTableToTree`).

The explicit `[[a.children]]` section path passes `latestCreatedBucket`; the inline-table path in `parseStringsToTomlTree` did **not** (it defaulted to `null`), so the check never fired and the first element's `children` fragment was reused for every element.

## Fix

Thread `latestCreatedBucket` through the inline-table insertion, exactly as the array-of-tables **section** path already does — a one-line behavioural change plus a comment.


Part of #360 (the array-of-tables alt-format case, separate from the inline-table crashes addressed by #385)