### PR TITLE
test: cover decoding a Gradle Version Catalog (#336)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,33 @@ val resultFromList = TomlFileReader.partiallyDecodeFromSource<MyClass>(serialize
 ```
 </details>
 
+<details>
+<summary>Decoding a real-world config file (e.g. Gradle <code>libs.versions.toml</code>)</summary>
+
+Any existing TOML config is just a TOML file, so ktoml can decode it straight into your own
+`@Serializable` classes — no special support needed. A Gradle version catalog is a good example:
+it uses maps of version / library / plugin declarations, `[bundles]`, inline `version = { ... }`
+objects, and the dotted `version.ref` key.
+
+```kotlin
+@Serializable
+data class GradleVersionCatalog(
+    val versions: Map<String, VersionDeclaration> = emptyMap(),
+    val libraries: Map<String, LibraryDeclaration> = emptyMap(),
+    val bundles: Map<String, List<String>> = emptyMap(),
+    val plugins: Map<String, PluginDeclaration> = emptyMap(),
+)
+// LibraryDeclaration has e.g. `module`, an inline `@SerialName("version")` object,
+// and the dotted `@SerialName("version.ref")` key.
+
+val catalog = Toml(inputConfig = TomlInputConfig(ignoreUnknownNames = true))
+    .decodeFromString<GradleVersionCatalog>(/* contents of libs.versions.toml */)
+```
+
+See [`GradleVersionCatalogTest`](ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/structures/GradleVersionCatalogTest.kt)
+for a complete, runnable example (including the `version.ref` and inline-table cases).
+</details>
+
 **Serialization:**
 <details>
 <summary>Straight-forward serialization</summary>
@@ -268,16 +295,6 @@ Toml(
     tomlString
 )
 ```
-
-## Samples
-
-### Gradle version catalog (`libs.versions.toml`)
-
-A Gradle version catalog is just a TOML file, so ktoml can decode one straight into your own
-`@Serializable` classes — maps of version / library / plugin declarations, `[bundles]`, inline
-`version = { ... }` objects, and the dotted `version.ref` key. See
-[`GradleVersionCatalogTest`](ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/structures/GradleVersionCatalogTest.kt)
-for a complete, runnable example.
 
 ## How ktoml works: examples
 :heavy_exclamation_mark: You can check how below examples work in [decoding ReadMeExampleTest](https://github.com/akuleshov7/ktoml/blob/main/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/ReadMeExampleTest.kt) and [encoding ReadMeExampleTest](https://github.com/akuleshov7/ktoml/blob/main/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/encoders/ReadMeExampleTest.kt).

--- a/README.md
+++ b/README.md
@@ -269,6 +269,16 @@ Toml(
 )
 ```
 
+## Samples
+
+### Gradle version catalog (`libs.versions.toml`)
+
+A Gradle version catalog is just a TOML file, so ktoml can decode one straight into your own
+`@Serializable` classes — maps of version / library / plugin declarations, `[bundles]`, inline
+`version = { ... }` objects, and the dotted `version.ref` key. See
+[`GradleVersionCatalogTest`](ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/structures/GradleVersionCatalogTest.kt)
+for a complete, runnable example.
+
 ## How ktoml works: examples
 :heavy_exclamation_mark: You can check how below examples work in [decoding ReadMeExampleTest](https://github.com/akuleshov7/ktoml/blob/main/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/ReadMeExampleTest.kt) and [encoding ReadMeExampleTest](https://github.com/akuleshov7/ktoml/blob/main/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/encoders/ReadMeExampleTest.kt).
 

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/structures/GradleVersionCatalogTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/structures/GradleVersionCatalogTest.kt
@@ -1,0 +1,127 @@
+package com.akuleshov7.ktoml.decoders.structures
+
+import com.akuleshov7.ktoml.Toml
+import com.akuleshov7.ktoml.TomlInputConfig
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Decoding a Gradle Version Catalog (`libs.versions.toml`) — issue orchestr7/ktoml#336.
+ *
+ * Exercises the combination that catalog files rely on: maps of objects ([Map] of [VersionDeclaration]
+ * / [LibraryDeclaration] / [PluginDeclaration]), a `Map<String, List<String>>` for bundles, nested
+ * inline tables as map values (`version = { ... }`), and a dotted `@SerialName("version.ref")` key.
+ */
+class GradleVersionCatalogTest {
+    @Serializable
+    data class VersionDeclaration(
+        val require: String? = null,
+        val strictly: String? = null,
+        val prefer: String? = null,
+        @SerialName("reject") val rejectList: List<String>? = null,
+    )
+
+    @Serializable
+    data class LibraryDeclaration(
+        val module: String? = null,
+        val group: String? = null,
+        val name: String? = null,
+        @SerialName("version") val versionInline: VersionDeclaration? = null,
+        @SerialName("version.ref") val versionRef: String? = null,
+    )
+
+    @Serializable
+    data class PluginDeclaration(
+        val id: String,
+        @SerialName("version") val versionInline: VersionDeclaration? = null,
+        @SerialName("version.ref") val versionRef: String? = null,
+    )
+
+    @Serializable
+    data class GradleVersionCatalog(
+        val versions: Map<String, VersionDeclaration> = emptyMap(),
+        val libraries: Map<String, LibraryDeclaration> = emptyMap(),
+        val bundles: Map<String, List<String>> = emptyMap(),
+        val plugins: Map<String, PluginDeclaration> = emptyMap(),
+    )
+
+    private val toml = Toml(inputConfig = TomlInputConfig(ignoreUnknownNames = true))
+
+    @Test
+    fun decodesMapOfVersionObjects() {
+        val decoded = toml.decodeFromString<GradleVersionCatalog>(
+            """
+            [versions]
+            platform = { require = "252.23892" }
+            kotlin = { strictly = "2.0.0" }
+            """.trimIndent(),
+        )
+        assertEquals("252.23892", decoded.versions["platform"]?.require)
+        assertEquals("2.0.0", decoded.versions["kotlin"]?.strictly)
+    }
+
+    @Test
+    fun decodesDottedVersionRefSerialName() {
+        val decoded = toml.decodeFromString<GradleVersionCatalog>(
+            """
+            [libraries]
+            annotations = { group = "org.jetbrains", name = "annotations", "version.ref" = "platform" }
+            """.trimIndent(),
+        )
+        val lib = decoded.libraries["annotations"]
+        assertEquals("org.jetbrains", lib?.group)
+        assertEquals("annotations", lib?.name)
+        // the dotted "version.ref" key binds to the @SerialName("version.ref") field
+        assertEquals("platform", lib?.versionRef)
+    }
+
+    @Test
+    fun decodesFullCatalogWithAllFourSections() {
+        val decoded = toml.decodeFromString<GradleVersionCatalog>(
+            """
+            [versions]
+            platform = { require = "252.23892" }
+            kotlin = { strictly = "2.0.0" }
+
+            [libraries]
+            annotations = { group = "org.jetbrains", name = "annotations", "version.ref" = "platform" }
+            stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version = { require = "2.0.0" } }
+
+            [bundles]
+            common = ["annotations", "stdlib"]
+
+            [plugins]
+            kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", "version.ref" = "kotlin" }
+            """.trimIndent(),
+        )
+
+        val expected = GradleVersionCatalog(
+            versions = mapOf(
+                "platform" to VersionDeclaration(require = "252.23892"),
+                "kotlin" to VersionDeclaration(strictly = "2.0.0"),
+            ),
+            libraries = mapOf(
+                "annotations" to LibraryDeclaration(
+                    group = "org.jetbrains",
+                    name = "annotations",
+                    versionRef = "platform",
+                ),
+                "stdlib" to LibraryDeclaration(
+                    module = "org.jetbrains.kotlin:kotlin-stdlib",
+                    versionInline = VersionDeclaration(require = "2.0.0"),
+                ),
+            ),
+            bundles = mapOf("common" to listOf("annotations", "stdlib")),
+            plugins = mapOf(
+                "kotlin-jvm" to PluginDeclaration(
+                    id = "org.jetbrains.kotlin.jvm",
+                    versionRef = "kotlin",
+                ),
+            ),
+        )
+        assertEquals(expected, decoded)
+    }
+}


### PR DESCRIPTION
Refs #336.

While looking at #336 I found that decoding a `libs.versions.toml`-shaped document **already works on current `main`** — including the parts that looked uncertain in the thread. This PR adds a regression test that locks the behaviour in.

It covers, in one document:
- `Map<String, VersionDeclaration / LibraryDeclaration / PluginDeclaration>` — maps of objects
- `Map<String, List<String>>` for `[bundles]`
- nested inline tables as map values (`version = { require = "..." }`)
- a dotted `@SerialName("version.ref")` key, bound from the quoted `"version.ref"` TOML key

All three test cases pass on `main` (verified at `ec84e4b`). If this matches what was intended in #336, the issue can likely be closed.