### PR TITLE
fix: resolve stack overflow on deeply nested arrays (#381)

### DIFF
--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/TomlMultilineString.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/TomlMultilineString.kt
@@ -114,6 +114,9 @@ internal class TomlMultilineString(
      * @return true if string is a last line of multiline value declaration
      */
     private fun isEndOfMultilineValue(multilineType: MultilineType): Boolean {
+        if (multilineType == MultilineType.ARRAY) {
+            return hasClosedMultilineArray()
+        }
         isNested ?: run {
             isNested = hasTwoConsecutiveSymbolsIgnoreWhitespaces(getLine(), multilineType.openSymbols[0])
         }
@@ -122,12 +125,7 @@ internal class TomlMultilineString(
             val clearedString = lines.joinToString("")
                 .filter { !it.isWhitespace() }
 
-            if (multilineType == MultilineType.ARRAY) {
-                clearedString.endsWith(multilineType.closingSymbols + multilineType.closingSymbols) ||
-                        clearedString.endsWith(multilineType.closingSymbols + "," + multilineType.closingSymbols)
-            } else {
-                clearedString.endsWith(multilineType.closingSymbols + multilineType.closingSymbols)
-            }
+            clearedString.endsWith(multilineType.closingSymbols + multilineType.closingSymbols)
         } else {
             // Checks if this line ends with closing symbols, allowing for whitespace or a comment after those
             // symbols. Note that we're not using [indexOfNextOutsideOfQuotes] here because the last line of a
@@ -142,6 +140,50 @@ internal class TomlMultilineString(
                 .trim()
                 .isEmpty()
         }
+    }
+
+    @Suppress("TOO_LONG_FUNCTION", "NESTED_BLOCK")
+    private fun hasClosedMultilineArray(): Boolean {
+        val value = getLine()
+            .substringAfter('=')
+            .replaceEscaped(config.allowEscapedQuotesInLiteralStrings)
+
+        var bracketBalance = 0
+        var currentQuoteStr: String? = null
+        var idx = 0
+
+        while (idx < value.length) {
+            val symbol = value[idx]
+            val quoteStr = currentQuoteStr
+
+            if (quoteStr == null) {
+                when (symbol) {
+                    '[' -> bracketBalance++
+                    ']' -> bracketBalance--
+                    '"', '\'' -> {
+                        currentQuoteStr = if (idx + 2 < value.length && value[idx + 1] == symbol && value[idx + 2] == symbol) {
+                            "$symbol$symbol$symbol"
+                        } else {
+                            symbol.toString()
+                        }
+                        idx += currentQuoteStr!!.length
+                        continue
+                    }
+                    else -> Unit
+                }
+            } else if (quoteStr[0] == symbol && idx + quoteStr.length <= value.length) {
+                val candidate = value.substring(idx, idx + quoteStr.length)
+                if (candidate == quoteStr) {
+                    currentQuoteStr = null
+                    idx += candidate.length
+                    continue
+                }
+            }
+
+            idx += 1
+        }
+
+        return bracketBalance == 0
     }
 
     private fun hasTwoConsecutiveSymbolsIgnoreWhitespaces(value: String, searchSymbol: Char): Boolean? {

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/values/TomlArray.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/values/TomlArray.kt
@@ -97,7 +97,7 @@ public class TomlArray internal constructor(
          */
         @Suppress("NESTED_BLOCK", "TOO_LONG_FUNCTION")
         private fun String.parseArray(lineNo: Int): MutableList<String> {
-            val trimmed = trimBrackets().trim().removeTrailingComma()
+            val trimmed = trim().trimBrackets().trim().removeTrailingComma()
             // covering cases when the array is intentionally blank: myArray = []. It should be empty and not contain null
             if (trimmed.isBlank()) {
                 return mutableListOf()

--- a/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/Issue381Test.kt
+++ b/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/Issue381Test.kt
@@ -1,0 +1,48 @@
+package com.akuleshov7.ktoml.compliance
+
+import com.akuleshov7.ktoml.TomlInputConfig
+import com.akuleshov7.ktoml.parsers.TomlParser
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class Issue381Test {
+    @Test
+    fun parsesNestedMultilineArrays() {
+        val toml = """
+            nest = [
+            	[
+            		["a"],
+            		[1, 2, [3]]
+            	]
+            ]
+        """.trimIndent()
+
+        val actualJson = TomlTestConverter.toJson(TomlParser(TomlInputConfig.compliant()).parseString(toml))
+        val expectedJson = Json.parseToJsonElement(
+            """
+            {"nest":[[[{"type":"string","value":"a"}],[{"type":"integer","value":"1"},{"type":"integer","value":"2"},[{"type":"integer","value":"3"}]]]]}
+            """.trimIndent()
+        )
+
+        assertEquals(expectedJson, actualJson)
+    }
+
+    @Test
+    fun parsesMultilineArraysWithInlineComments() {
+        val toml = """
+            arr5 = [[[[#["#"],
+            ["#"]]]]#]
+            ]
+        """.trimIndent()
+
+        val actualJson = TomlTestConverter.toJson(TomlParser(TomlInputConfig.compliant()).parseString(toml))
+        val expectedJson = Json.parseToJsonElement(
+            """
+            {"arr5":[[[[[{"type":"string","value":"#"}]]]]]}
+            """.trimIndent()
+        )
+
+        assertEquals(expectedJson, actualJson)
+    }
+}

--- a/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
+++ b/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
@@ -115,11 +115,13 @@ data object ValidTomlRejected : KnownFailure {
     )
 }
 
-/** Stack overflow on deeply nested structures */
+/**
+ * Deeply nested arrays no longer overflow (fixed here). `comment/tricky.toml` still fails on unrelated
+ * value/comment handling, so it stays baselined.
+ */
 data object StackOverflowOnNesting : KnownFailure {
     override val issue = 381
     override val tests = listOf(
-        "valid/array/nested-double.toml",
         "valid/comment/tricky.toml",
     )
 }


### PR DESCRIPTION
Fixes #381 (the stack overflow).

Deeply nested arrays could overflow the stack because multiline-array end detection used a "does the joined string end with `]]`" check. This rewrites it to bracket-balance counting that ignores brackets inside quoted strings.

- `TomlArray`: trim leading whitespace before bracket removal
- `TomlMultilineString`: `hasClosedMultilineArray()` - balance `[`/`]` outside quotes to decide when a multiline array is closed
- `Issue381Test`: regression coverage (nested arrays + inline-comment edge cases)

Compliance suite: `valid/array/nested-double.toml` now passes and is removed from the baseline. `valid/comment/tricky.toml` no longer overflows either, but it still fails on unrelated value/comment handling (floats-with-comments like `10e2#1`, etc.), so it stays baselined under #381 for a separate follow-up rather than being falsely marked as passing.
