### PR TITLE
fix: preserve timezone offset in offset date-times (#375)

### DIFF
--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/decoders/TomlAbstractDecoder.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/decoders/TomlAbstractDecoder.kt
@@ -7,6 +7,7 @@ import com.akuleshov7.ktoml.tree.nodes.pairs.values.TomlBasicString
 import com.akuleshov7.ktoml.tree.nodes.pairs.values.TomlDouble
 import com.akuleshov7.ktoml.tree.nodes.pairs.values.TomlLiteralString
 import com.akuleshov7.ktoml.tree.nodes.pairs.values.TomlLong
+import com.akuleshov7.ktoml.tree.nodes.pairs.values.TomlOffsetDateTime
 import com.akuleshov7.ktoml.tree.nodes.pairs.values.TomlUnsignedLong
 import com.akuleshov7.ktoml.utils.FloatingPointLimitsEnum
 import com.akuleshov7.ktoml.utils.FloatingPointLimitsEnum.*
@@ -109,7 +110,7 @@ public abstract class TomlAbstractDecoder : AbstractDecoder() {
     @Suppress("UNCHECKED_CAST")
     override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T =
         when (deserializer.descriptor) {
-            instantSerializer.descriptor -> decodePrimitiveType<Instant>() as T
+            instantSerializer.descriptor -> decodeInstant() as T
             localDateTimeSerializer.descriptor -> decodePrimitiveType<LocalDateTime>() as T
             localDateSerializer.descriptor -> decodePrimitiveType<LocalDate>() as T
             localTimeSerializer.descriptor -> decodePrimitiveType<LocalTime>() as T
@@ -135,6 +136,24 @@ public abstract class TomlAbstractDecoder : AbstractDecoder() {
      * >>> expected by user: data class A(val a: Int)
      * >>> TomlString cannot be cast to Int, user made a mistake -> IllegalTypeException
      */
+    @OptIn(ExperimentalTime::class)
+    private fun decodeInstant(): Instant {
+        val keyValue = decodeKeyValue()
+        return try {
+            when (val content = keyValue.value.content) {
+                is Instant -> content
+                is TomlOffsetDateTime -> content.instant
+                else -> throw ClassCastException()
+            }
+        } catch (e: ClassCastException) {
+            throw IllegalTypeException(
+                "Cannot decode the key [${keyValue.key.last()}] with the value [${keyValue.value.content}]" +
+                        " and with the provided type [${Instant::class}]. Please check the type in your Serializable class or it's nullability",
+                keyValue.lineNo
+            )
+        }
+    }
+
     private inline fun <reified T> decodePrimitiveType(): T {
         val keyValue = decodeKeyValue()
         try {

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/values/TomlDateTime.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/values/TomlDateTime.kt
@@ -1,14 +1,70 @@
+/**
+ * This file contains datetime-related AST node types for TOML parsing.
+ */
+
 package com.akuleshov7.ktoml.tree.nodes.pairs.values
 
 import com.akuleshov7.ktoml.TomlOutputConfig
 import com.akuleshov7.ktoml.exceptions.TomlWritingException
 import com.akuleshov7.ktoml.writers.TomlEmitter
-
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
+
+private const val FRACTIONAL_SECOND_PRECISION = 3
+
+/**
+ * Preserves the original textual representation of an offset date-time while still exposing the parsed [instant].
+ *
+ * @property raw original TOML date-time text
+ * @property instant parsed instant value
+ */
+@OptIn(ExperimentalTime::class)
+public data class TomlOffsetDateTime(
+    public val raw: String,
+    public val instant: Instant,
+) {
+    override fun toString(): String = raw
+
+    internal fun toRfc3339String(): String {
+        val normalized = raw
+            .replaceFirst(' ', 'T')
+            .replaceFirst('t', 'T')
+            .replaceFirst('z', 'Z')
+        val timeStart = normalized.indexOf('T')
+        if (timeStart == -1) {
+            return normalized
+        }
+
+        val offsetStart = normalized.indexOfAny(charArrayOf('Z', '+', '-'), startIndex = timeStart + 1)
+        if (offsetStart == -1) {
+            return normalized
+        }
+
+        val timePart = normalized.substring(timeStart + 1, offsetStart)
+        val dotIndex = timePart.indexOf('.')
+        if (dotIndex == -1) {
+            return normalized
+        }
+
+        val fraction = timePart.substring(dotIndex + 1)
+        if (fraction.length >= FRACTIONAL_SECOND_PRECISION) {
+            return normalized
+        }
+
+        val paddedTime = buildString {
+            append(timePart.substring(0, dotIndex + 1))
+            append(fraction.padEnd(FRACTIONAL_SECOND_PRECISION, '0'))
+        }
+        return buildString {
+            append(normalized.substring(0, timeStart + 1))
+            append(paddedTime)
+            append(normalized.substring(offsetStart))
+        }
+    }
+}
 
 /**
  * Toml AST Node for a representation of date-time types (offset date-time, local date-time, local date, local time)
@@ -27,6 +83,7 @@ internal constructor(
         @OptIn(ExperimentalTime::class)
         when (val content = content) {
             is Instant -> emitter.emitValue(content)
+            is TomlOffsetDateTime -> emitter.emitValue(content)
             is LocalDateTime -> emitter.emitValue(content)
             is LocalDate -> emitter.emitValue(content)
             is LocalTime -> emitter.emitValue(content)
@@ -42,7 +99,16 @@ internal constructor(
         private fun String.parseToDateTime(): Any = try {
             // Offset date-time
             // TOML spec allows a space instead of the T, try replacing the first space by a T
-            Instant.parse(replaceFirst(' ', 'T'))
+            val normalized = this
+                .replaceFirst(' ', 'T')
+                .replaceFirst('t', 'T')
+                .replaceFirst('z', 'Z')
+            val instant = Instant.parse(normalized)
+            if (normalized.hasExplicitOffset()) {
+                TomlOffsetDateTime(this, instant)
+            } else {
+                instant
+            }
         } catch (e: IllegalArgumentException) {
             try {
                 // Local date-time
@@ -56,6 +122,14 @@ internal constructor(
                     LocalTime.parse(this)
                 }
             }
+        }
+
+        private fun String.hasExplicitOffset(): Boolean {
+            val timeStart = indexOf('T')
+            if (timeStart == -1) {
+                return false
+            }
+            return indexOfAny(charArrayOf('+', '-'), startIndex = timeStart + 1) != -1
         }
     }
 }

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/writers/TomlEmitter.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/writers/TomlEmitter.kt
@@ -2,12 +2,12 @@ package com.akuleshov7.ktoml.writers
 
 import com.akuleshov7.ktoml.TomlOutputConfig
 import com.akuleshov7.ktoml.tree.nodes.TableType
+import com.akuleshov7.ktoml.tree.nodes.pairs.values.TomlOffsetDateTime
 import com.akuleshov7.ktoml.utils.isBareKey
 import com.akuleshov7.ktoml.utils.isLiteralKeyCandidate
 import com.akuleshov7.ktoml.utils.newLineChar
 import com.akuleshov7.ktoml.writers.IntegerRepresentation.DECIMAL
 import com.akuleshov7.ktoml.writers.IntegerRepresentation.GROUPED
-
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
@@ -290,6 +290,14 @@ public abstract class TomlEmitter(config: TomlOutputConfig) {
      */
     @OptIn(ExperimentalTime::class)
     public fun emitValue(instant: Instant): TomlEmitter = emit(instant.toString())
+
+    /**
+     * Emits an offset date-time value while preserving its original offset.
+     *
+     * @param offsetDateTime
+     * @return this instance
+     */
+    public fun emitValue(offsetDateTime: TomlOffsetDateTime): TomlEmitter = emit(offsetDateTime.toString())
 
     /**
      * Emits a [LocalDateTime] value.

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/writers/ValueWriteTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/writers/ValueWriteTest.kt
@@ -131,11 +131,13 @@ class PrimitiveValueWriteTest {
     @Test
     fun dateTimeWriteTest() {
         val instant = "1979-05-27T07:32:00Z"
+        val offsetInstant = "1979-05-27T00:32:00-07:00"
         val localDt = "1979-05-27T07:32"
         val localD = "1979-05-27"
         val localT = "07:32:32"
 
         testTomlValue(TomlDateTime(kotlin.time.Instant.parse(instant)), instant)
+        testTomlValue(TomlDateTime(offsetInstant, 1), offsetInstant)
         testTomlValue(TomlDateTime(LocalDateTime.parse(localDt)), localDt)
         testTomlValue(TomlDateTime(LocalDate.parse(localD)), localD)
         testTomlValue(TomlDateTime(LocalTime.parse(localT)), localT)

--- a/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
+++ b/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
@@ -11,7 +11,6 @@ package com.akuleshov7.ktoml.compliance
  *
  * | Category | Issue |
  * |----------|-------|
- * | Datetime offset normalized to UTC | [#375](https://github.com/orchestr7/ktoml/issues/375) |
  * | Float representation lost | [#376](https://github.com/orchestr7/ktoml/issues/376) |
  * | Dotted key expansion incorrect | [#377](https://github.com/orchestr7/ktoml/issues/377) |
  * | Array-of-tables structure | [#378](https://github.com/orchestr7/ktoml/issues/378) |
@@ -33,18 +32,6 @@ sealed interface KnownFailure {
     val tests: List<String>
 
     val issueUrl: String get() = "https://github.com/orchestr7/ktoml/issues/$issue"
-}
-
-/** Offset datetimes normalized to UTC, losing original timezone */
-data object DatetimeOffsetLoss : KnownFailure {
-    override val issue = 375
-    override val tests = listOf(
-        "valid/comment/everywhere.toml",
-        "valid/datetime/milliseconds.toml",
-        "valid/datetime/timezone.toml",
-        "valid/spec-example-1.toml",
-        "valid/spec-example-1-compact.toml",
-    )
 }
 
 /** Scientific notation lost after parsing to Double */
@@ -402,7 +389,6 @@ data object TomlOneOneMissingValidation : KnownFailure {
  * All known failure groups. Used by [TomlTestSuite] to build the lookup map.
  */
 val allKnownFailures: List<KnownFailure> = listOf(
-    DatetimeOffsetLoss,
     FloatRepresentationLoss,
     DottedKeyExpansion,
     ArrayOfTablesStructure,

--- a/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestConverter.kt
+++ b/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestConverter.kt
@@ -64,6 +64,7 @@ object TomlTestConverter {
     @OptIn(ExperimentalTime::class)
     private fun datetimeToJson(content: Any): JsonElement = when (content) {
         is Instant -> tagged("datetime", content.toString())
+        is TomlOffsetDateTime -> tagged("datetime", content.toRfc3339String())
         is LocalDateTime -> tagged("datetime-local", formatLocalDateTime(content))
         is LocalDate -> tagged("date-local", content.toString())
         is LocalTime -> tagged("time-local", formatLocalTime(content))


### PR DESCRIPTION
Fixes #375.

Offset date-times were parsed straight into a `kotlin.time.Instant`, which normalizes to UTC and discards the original timezone offset (e.g. `-07:00` became `Z`). This change introduces a `TomlOffsetDateTime` AST value that keeps the original TOML text alongside the parsed `Instant`, so round-tripping and toml-test JSON output preserve the offset. Local date-times / dates / times and offsets that are already UTC are unaffected. `Instant`-typed fields still decode via `decodeInstant`, which accepts both representations.

Removes the `DatetimeOffsetLoss` baseline entry — valid/comment/everywhere.toml, valid/datetime/milliseconds.toml, valid/datetime/timezone.toml, valid/spec-example-1.toml, valid/spec-example-1-compact.toml now pass.
