### PR TITLE
fix: correct array-of-tables AST structure in edge cases (#378)

### DIFF
--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/TomlNode.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/TomlNode.kt
@@ -108,49 +108,32 @@ public sealed class TomlNode(
      * @param latestCreatedBucket the bucket of the latest created array of tables
      * @return link to the inserted table inside the tree
      */
-    @Suppress("TOO_LONG_FUNCTION")
+    @Suppress("UNUSED_PARAMETER")
     public fun insertTableToTree(tomlTable: TomlTable, latestCreatedBucket: TomlArrayOfTablesElement? = null): TomlNode {
-        // important to save and update parental node
-        var previousParent = this
-        // going through parts of the table to create new tables in the tree in case some fragments are missing
-        tomlTable.tablesList.forEachIndexed { level, subTable ->
-            val foundTable = previousParent.findTableInAstByName(subTable)
-            // flag that will be used to check if we need to create a copy of the table in the tree or not
-            var constructNewBucket = false
-            // if the part of the table was found and it is inside the array - we need to determine if we need to create a copy or not
-            if (foundTable != null && foundTable.parent is TomlArrayOfTablesElement) {
-                val freeBucket = (foundTable.parent?.parent as TomlTable).children.last()
-                // need to create a new array of tables in the tree only
-                // if there was an array before:
-                // [[a]]                                                                      [[a]]
-                // [[a.b]]   in case of the nested array we should not create a copy:      [[a.b]]
-                // [[a]]                                                                       [[a.b]]
-                // [[a.b]]                                                                 [[a.b]]
-                if (tomlTable.type == TableType.PRIMITIVE || freeBucket == latestCreatedBucket) {
-                    previousParent = freeBucket
-                    constructNewBucket = true
-                }
-            }
+        var previousParent: TomlNode = this
 
-            previousParent = if (foundTable != null && !constructNewBucket) {
-                // in case of inline tables we generate a structure that already has key-values inserted to it,
-                // so we need to copy these children to the TOML AST
-                if (level == tomlTable.tablesList.lastIndex) {
-                    tomlTable.children.forEach {
-                        foundTable.appendChild(it)
-                    }
+        tomlTable.tablesList.forEachIndexed { level, subTable ->
+            val isLastLevel = level == tomlTable.tablesList.lastIndex
+            val foundTable = previousParent.findTableInAstByName(subTable)
+
+            previousParent = when {
+                foundTable != null && isLastLevel && foundTable.type == tomlTable.type -> {
+                    tomlTable.children.forEach(foundTable::appendChild)
+                    foundTable
                 }
-                foundTable
-            } else {
-                if (level == tomlTable.tablesList.lastIndex) {
+
+                foundTable != null -> foundTable.resolveInsertionParent()
+
+                isLastLevel -> {
                     previousParent.determineParentAndInsertFragmentOfTable(tomlTable)
                     tomlTable
-                } else {
-                    // creating a synthetic (technical) fragment of the table
+                }
+
+                else -> {
                     val newChildTableName = TomlTable(
                         TomlKey(subTable, lineNo),
                         lineNo,
-                        tomlTable.type,
+                        TableType.PRIMITIVE,
                         tomlTable.comments,
                         tomlTable.inlineComment,
                         isSynthetic = true
@@ -223,6 +206,13 @@ public sealed class TomlNode(
             this.appendChild(childTable)
         }
     }
+
+    private fun TomlTable.resolveInsertionParent(): TomlNode =
+        if (type == TableType.ARRAY) {
+            children.lastOrNull() as? TomlArrayOfTablesElement ?: this
+        } else {
+            this
+        }
 
     /**
      * Writes this node as text to [emitter].

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/tables/TomlTable.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/tables/TomlTable.kt
@@ -7,9 +7,9 @@ package com.akuleshov7.ktoml.tree.nodes
 import com.akuleshov7.ktoml.TomlOutputConfig
 import com.akuleshov7.ktoml.exceptions.ParseException
 import com.akuleshov7.ktoml.parsers.takeBeforeComment
+import com.akuleshov7.ktoml.parsers.trimAllQuotes
 import com.akuleshov7.ktoml.parsers.trimBrackets
 import com.akuleshov7.ktoml.parsers.trimDoubleBrackets
-import com.akuleshov7.ktoml.parsers.trimQuotes
 import com.akuleshov7.ktoml.tree.nodes.pairs.keys.TomlKey
 import com.akuleshov7.ktoml.writers.TomlEmitter
 import com.akuleshov7.ktoml.writers.TomlStringEmitter
@@ -43,7 +43,7 @@ public class TomlTable(
     public var tablesList: List<String> = fullTableKey.keyParts.runningReduce { prev, cur -> "$prev.$cur" }
 
     // short table name (only the name without parental prefix, like a - it is used in decoder and encoder)
-    public override val name: String = fullTableKey.keyParts.last().trimQuotes()
+    public override val name: String = fullTableKey.keyParts.last().trimAllQuotes()
 
     public constructor(
         content: String,

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/parsers/ArraysOfTablesTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/parsers/ArraysOfTablesTest.kt
@@ -97,7 +97,7 @@ class ArraysOfTablesTest {
         assertEquals(
             """
                 | - TomlFile (rootNode)
-                |     - TomlTable ([[fruits]])
+                |     - TomlTable ([fruits])
                 |         - TomlTable ([[fruits.varieties]])
                 |             - TomlArrayOfTablesElement (technical_node)
                 |                 - TomlKeyValuePrimitive (name="red delicious")
@@ -126,7 +126,7 @@ class ArraysOfTablesTest {
         assertEquals(
             """
                 | - TomlFile (rootNode)
-                |     - TomlTable ([[fruits]])
+                |     - TomlTable ([fruits])
                 |         - TomlTable ([[fruits.varieties]])
                 |             - TomlArrayOfTablesElement (technical_node)
                 |                 - TomlKeyValuePrimitive (name="red delicious")
@@ -285,7 +285,6 @@ class ArraysOfTablesTest {
                     |             - TomlTable ([fruits.physical])
                     |                 - TomlKeyValuePrimitive (color="red")
                     |                 - TomlKeyValuePrimitive (shape="round")
-                    |             - TomlTable ([fruits.physical])
                     |                 - TomlTable ([fruits.physical.inside])
                     |                     - TomlKeyValuePrimitive (color="red")
                     |                     - TomlKeyValuePrimitive (shape="round")
@@ -396,15 +395,15 @@ class ArraysOfTablesTest {
         assertEquals(
             """
                         | - TomlFile (rootNode)
-                        |     - TomlTable ([[a]])
+                        |     - TomlTable ([a])
                         |         - TomlTable ([[a.b]])
                         |             - TomlArrayOfTablesElement (technical_node)
                         |                 - TomlTable ([[a.b.c]])
                         |                     - TomlArrayOfTablesElement (technical_node)
                         |                     - TomlArrayOfTablesElement (technical_node)
                         |                         - TomlKeyValuePrimitive (a=1)
-                        |                         - TomlTable ([[a.b.c.d]])
-                        |                             - TomlTable ([[a.b.c.d.e]])
+                        |                         - TomlTable ([a.b.c.d])
+                        |                             - TomlTable ([a.b.c.d.e])
                         |                                 - TomlTable ([[a.b.c.d.e.f]])
                         |                                     - TomlArrayOfTablesElement (technical_node)
                         |             - TomlArrayOfTablesElement (technical_node)
@@ -515,7 +514,7 @@ class ArraysOfTablesTest {
         assertEquals(
             """
                 | - TomlFile (rootNode)
-                |     - TomlTable ([[a]])
+                |     - TomlTable ([a])
                 |         - TomlTable ([[a.b]])
                 |             - TomlArrayOfTablesElement (technical_node)
                 |                 - TomlKeyValuePrimitive (name=1)
@@ -555,7 +554,7 @@ class ArraysOfTablesTest {
                 | - TomlFile (rootNode)
                 |     - TomlTable ([a])
                 |         - TomlKeyValuePrimitive (name=1)
-                |         - TomlTable ([[a.b]])
+                |         - TomlTable ([a.b])
                 |             - TomlTable ([[a.b.c]])
                 |                 - TomlArrayOfTablesElement (technical_node)
                 |                     - TomlKeyValuePrimitive (name=2)
@@ -636,7 +635,6 @@ class ArraysOfTablesTest {
                 |             - TomlKeyValuePrimitive (simple=5)
                 |             - TomlTable ([table.item])
                 |                 - TomlKeyValuePrimitive (simple=6)
-                |             - TomlTable ([table.item])
                 |                 - TomlTable ([table.item.complex])
                 |                     - TomlKeyValuePrimitive (a=7)
                 |                     - TomlKeyValuePrimitive (b=8)

--- a/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
+++ b/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
@@ -14,7 +14,6 @@ package com.akuleshov7.ktoml.compliance
  * | Datetime offset normalized to UTC | [#375](https://github.com/orchestr7/ktoml/issues/375) |
  * | Float representation lost | [#376](https://github.com/orchestr7/ktoml/issues/376) |
  * | Dotted key expansion incorrect | [#377](https://github.com/orchestr7/ktoml/issues/377) |
- * | Array-of-tables structure | [#378](https://github.com/orchestr7/ktoml/issues/378) |
  * | Key names not unquoted | [#379](https://github.com/orchestr7/ktoml/issues/379) |
  * | Parser rejects valid TOML | [#380](https://github.com/orchestr7/ktoml/issues/380) |
  * | Stack overflow on deep nesting | [#381](https://github.com/orchestr7/ktoml/issues/381) |
@@ -68,18 +67,6 @@ data object DottedKeyExpansion : KnownFailure {
         "valid/key/dotted-04.toml",
         "valid/key/dotted-empty.toml",
         "valid/key/quoted-dots.toml",
-    )
-}
-
-/** Array-of-tables produces wrong AST structure in edge cases */
-data object ArrayOfTablesStructure : KnownFailure {
-    override val issue = 378
-    override val tests = listOf(
-        "valid/array/open-parent-table.toml",
-        "valid/table/array-empty-name.toml",
-        "valid/table/array-implicit.toml",
-        "valid/table/array-implicit-and-explicit-after.toml",
-        "valid/table/array-table-array.toml",
     )
 }
 
@@ -405,7 +392,6 @@ val allKnownFailures: List<KnownFailure> = listOf(
     DatetimeOffsetLoss,
     FloatRepresentationLoss,
     DottedKeyExpansion,
-    ArrayOfTablesStructure,
     KeyNameQuoting,
     ValidTomlRejected,
     StackOverflowOnNesting,


### PR DESCRIPTION
Fixes #378.

Reworks `TomlNode.insertTableToTree` so array-of-tables fragments resolve to the correct insertion parent instead of duplicating synthetic table nodes. Synthetic fragments are now always created as `PRIMITIVE`, and an existing node is only reused when its `TableType` matches, otherwise insertion descends into the last `TomlArrayOfTablesElement`. Also switches `TomlTable.name` to `trimAllQuotes()` so quoted table names are unquoted consistently.

Removes the `ArrayOfTablesStructure` baseline entry — `valid/array/open-parent-table.toml`, `valid/table/array-empty-name.toml`, `valid/table/array-implicit.toml`, `valid/table/array-implicit-and-explicit-after.toml`, and `valid/table/array-table-array.toml` now pass.
