### PR TITLE
fix: properly unquote/unescape key names in AST (#379)

### DIFF
--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/StringUtils.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/StringUtils.kt
@@ -139,6 +139,9 @@ internal fun String.trimAllQuotes(): String {
  *
  * Double-quoted keys use basic-string escaping, single-quoted keys are literal,
  * and bare keys are returned as-is.
+ *
+ * @param lineNo the line number for error reporting
+ * @return the unquoted and unescaped key name
  */
 internal fun String.parseKeyName(lineNo: Int): String = when {
     startsWith('"') && endsWith('"') -> trimQuotes().convertSpecialCharacters(lineNo)

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/StringUtils.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/StringUtils.kt
@@ -5,6 +5,7 @@
 package com.akuleshov7.ktoml.parsers
 
 import com.akuleshov7.ktoml.exceptions.ParseException
+import com.akuleshov7.ktoml.utils.convertSpecialCharacters
 import com.akuleshov7.ktoml.utils.newLineChar
 
 private const val MULTILINE_STRING_QUOTE_LENGTH = 3
@@ -131,6 +132,18 @@ internal fun String.trimAllQuotes(): String {
     } else {
         this
     }
+}
+
+/**
+ * Parses a TOML key part into the AST form.
+ *
+ * Double-quoted keys use basic-string escaping, single-quoted keys are literal,
+ * and bare keys are returned as-is.
+ */
+internal fun String.parseKeyName(lineNo: Int): String = when {
+    startsWith('"') && endsWith('"') -> trimQuotes().convertSpecialCharacters(lineNo)
+    startsWith('\'') && endsWith('\'') -> trimSingleQuotes()
+    else -> this
 }
 
 /**

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/TomlNode.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/TomlNode.kt
@@ -80,9 +80,12 @@ public sealed class TomlNode(
      */
     public fun findTableInAstByName(tableName: String): TomlTable? {
         val tableKey = TomlKey(tableName, lineNo)
+        val tableKeyName = tableKey.last()
 
         // getting all child-tables (and arrays of tables) that have the same name as we are trying to find
-        val simpleTable = this.children.filterIsInstance<TomlTable>().filter { it.fullTableKey == tableKey }
+        val simpleTable = this.children.filterIsInstance<TomlTable>().filter {
+            it.fullTableKey == tableKey || it.name == tableKeyName
+        }
         // there cannot be more than 1 table node with the same name on the same level in the tree
         if (simpleTable.size > 1) {
             throw InternalAstException(
@@ -97,7 +100,7 @@ public sealed class TomlNode(
             .map { it.children }
             .flatten()
             .filterIsInstance<TomlTable>()
-            .filter { it.fullTableKey == tableKey }
+            .filter { it.fullTableKey == tableKey || it.name == tableKeyName }
             .toList()
         // return the table that we found among the list of child tables or in the array of tables
         return simpleTable.lastOrNull() ?: tableFromElements.lastOrNull()

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/keys/TomlKey.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/keys/TomlKey.kt
@@ -2,8 +2,8 @@ package com.akuleshov7.ktoml.tree.nodes.pairs.keys
 
 import com.akuleshov7.ktoml.TomlOutputConfig
 import com.akuleshov7.ktoml.exceptions.TomlWritingException
+import com.akuleshov7.ktoml.parsers.parseKeyName
 import com.akuleshov7.ktoml.parsers.splitKeyToTokens
-import com.akuleshov7.ktoml.parsers.trimAllQuotes
 import com.akuleshov7.ktoml.writers.TomlEmitter
 import com.akuleshov7.ktoml.writers.TomlStringEmitter
 
@@ -31,10 +31,10 @@ public class TomlKey internal constructor(
     ) : this(rawContent.splitKeyToTokens(lineNo))
 
     /**
-     * Gets the last key part, with all whitespace and quotes trimmed, i.e. `c` in
-     * `a.b.' c '`
+     * Gets the last key part in AST form, with quotes removed and escapes resolved
+     * for basic keys.
      */
-    public fun last(): String = keyParts.last().trimAllQuotes().trim()
+    public fun last(): String = keyParts.last().parseKeyName(lineNo = 0)
 
     public fun write(emitter: TomlEmitter) {
         val keys = keyParts

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/tables/TomlTable.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/tables/TomlTable.kt
@@ -6,10 +6,10 @@ package com.akuleshov7.ktoml.tree.nodes
 
 import com.akuleshov7.ktoml.TomlOutputConfig
 import com.akuleshov7.ktoml.exceptions.ParseException
+import com.akuleshov7.ktoml.parsers.parseKeyName
 import com.akuleshov7.ktoml.parsers.takeBeforeComment
 import com.akuleshov7.ktoml.parsers.trimBrackets
 import com.akuleshov7.ktoml.parsers.trimDoubleBrackets
-import com.akuleshov7.ktoml.parsers.trimQuotes
 import com.akuleshov7.ktoml.tree.nodes.pairs.keys.TomlKey
 import com.akuleshov7.ktoml.writers.TomlEmitter
 import com.akuleshov7.ktoml.writers.TomlStringEmitter
@@ -43,7 +43,7 @@ public class TomlTable(
     public var tablesList: List<String> = fullTableKey.keyParts.runningReduce { prev, cur -> "$prev.$cur" }
 
     // short table name (only the name without parental prefix, like a - it is used in decoder and encoder)
-    public override val name: String = fullTableKey.keyParts.last().trimQuotes()
+    public override val name: String = fullTableKey.keyParts.last().parseKeyName(lineNo)
 
     public constructor(
         content: String,

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/parsers/DottedKeyParserTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/parsers/DottedKeyParserTest.kt
@@ -27,7 +27,11 @@ class DottedKeyParserTest {
         assertEquals(true, test.isDotted)
 
         test = TomlKey("\"  a  \"", 0)
-        assertEquals("a", test.last())
+        assertEquals("  a  ", test.last())
+        assertEquals(false, test.isDotted)
+
+        test = TomlKey("\"\\ttab\\ttab\\t\"", 0)
+        assertEquals("\ttab\ttab\t", test.last())
         assertEquals(false, test.isDotted)
 
         test = TomlKey("a.b.c", 0)
@@ -35,7 +39,7 @@ class DottedKeyParserTest {
         assertEquals(true, test.isDotted)
 
         test = TomlKey("a.\"  b  .c \"", 0)
-        assertEquals("b  .c", test.last())
+        assertEquals("  b  .c ", test.last())
         assertEquals(true, test.isDotted)
 
         test = TomlKey("a  .  b .  c ", 0)

--- a/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
+++ b/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
@@ -15,7 +15,6 @@ package com.akuleshov7.ktoml.compliance
  * | Float representation lost | [#376](https://github.com/orchestr7/ktoml/issues/376) |
  * | Dotted key expansion incorrect | [#377](https://github.com/orchestr7/ktoml/issues/377) |
  * | Array-of-tables structure | [#378](https://github.com/orchestr7/ktoml/issues/378) |
- * | Key names not unquoted | [#379](https://github.com/orchestr7/ktoml/issues/379) |
  * | Parser rejects valid TOML | [#380](https://github.com/orchestr7/ktoml/issues/380) |
  * | Stack overflow on deep nesting | [#381](https://github.com/orchestr7/ktoml/issues/381) |
  * | Multiline string escape handling | [#382](https://github.com/orchestr7/ktoml/issues/382) |
@@ -80,18 +79,6 @@ data object ArrayOfTablesStructure : KnownFailure {
         "valid/table/array-implicit.toml",
         "valid/table/array-implicit-and-explicit-after.toml",
         "valid/table/array-table-array.toml",
-    )
-}
-
-/** Key names retain quote characters in AST name property */
-data object KeyNameQuoting : KnownFailure {
-    override val issue = 379
-    override val tests = listOf(
-        "valid/key/space.toml",
-        "valid/multibyte.toml",
-        "valid/table/empty-name.toml",
-        "valid/table/with-literal-string.toml",
-        "valid/table/with-single-quotes.toml",
     )
 }
 
@@ -406,7 +393,6 @@ val allKnownFailures: List<KnownFailure> = listOf(
     FloatRepresentationLoss,
     DottedKeyExpansion,
     ArrayOfTablesStructure,
-    KeyNameQuoting,
     ValidTomlRejected,
     StackOverflowOnNesting,
     MultilineStringEscape,


### PR DESCRIPTION
Fixes #379.

Key names in the AST retained their surrounding quotes and left escape sequences unresolved, so quoted/escaped keys did not match their intended names. This adds a `parseKeyName` helper that strips quotes and applies basic-string escaping for double-quoted keys, treats single-quoted keys as literals, and leaves bare keys untouched. `TomlKey.last()`, `TomlTable.name`, and table lookup in `TomlNode` now go through it.

Removes the `KeyNameQuoting` baseline entry — `valid/key/space.toml`, `valid/multibyte.toml`, `valid/table/empty-name.toml`, `valid/table/with-literal-string.toml`, and `valid/table/with-single-quotes.toml` now pass.
