### PR TITLE
fix: array-of-tables structure + key/table-name unquoting (#377, #378, #379)

### DIFF
--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/StringUtils.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/StringUtils.kt
@@ -139,6 +139,9 @@ internal fun String.trimAllQuotes(): String {
  *
  * Double-quoted keys use basic-string escaping, single-quoted keys are literal,
  * and bare keys are returned as-is.
+ *
+ * @param lineNo the line number for error reporting
+ * @return the unquoted and unescaped key name
  */
 internal fun String.parseKeyName(lineNo: Int): String = when {
     startsWith('"') && endsWith('"') -> trimQuotes().convertSpecialCharacters(lineNo)

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/StringUtils.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/StringUtils.kt
@@ -5,6 +5,7 @@
 package com.akuleshov7.ktoml.parsers
 
 import com.akuleshov7.ktoml.exceptions.ParseException
+import com.akuleshov7.ktoml.utils.convertSpecialCharacters
 import com.akuleshov7.ktoml.utils.newLineChar
 
 private const val MULTILINE_STRING_QUOTE_LENGTH = 3
@@ -131,6 +132,18 @@ internal fun String.trimAllQuotes(): String {
     } else {
         this
     }
+}
+
+/**
+ * Parses a TOML key part into the AST form.
+ *
+ * Double-quoted keys use basic-string escaping, single-quoted keys are literal,
+ * and bare keys are returned as-is.
+ */
+internal fun String.parseKeyName(lineNo: Int): String = when {
+    startsWith('"') && endsWith('"') -> trimQuotes().convertSpecialCharacters(lineNo)
+    startsWith('\'') && endsWith('\'') -> trimSingleQuotes()
+    else -> this
 }
 
 /**

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/TomlNode.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/TomlNode.kt
@@ -80,9 +80,12 @@ public sealed class TomlNode(
      */
     public fun findTableInAstByName(tableName: String): TomlTable? {
         val tableKey = TomlKey(tableName, lineNo)
+        val tableKeyName = tableKey.last()
 
         // getting all child-tables (and arrays of tables) that have the same name as we are trying to find
-        val simpleTable = this.children.filterIsInstance<TomlTable>().filter { it.fullTableKey == tableKey }
+        val simpleTable = this.children.filterIsInstance<TomlTable>().filter {
+            it.fullTableKey == tableKey || it.name == tableKeyName
+        }
         // there cannot be more than 1 table node with the same name on the same level in the tree
         if (simpleTable.size > 1) {
             throw InternalAstException(
@@ -97,7 +100,7 @@ public sealed class TomlNode(
             .map { it.children }
             .flatten()
             .filterIsInstance<TomlTable>()
-            .filter { it.fullTableKey == tableKey }
+            .filter { it.fullTableKey == tableKey || it.name == tableKeyName }
             .toList()
         // return the table that we found among the list of child tables or in the array of tables
         return simpleTable.lastOrNull() ?: tableFromElements.lastOrNull()

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/TomlNode.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/TomlNode.kt
@@ -108,49 +108,32 @@ public sealed class TomlNode(
      * @param latestCreatedBucket the bucket of the latest created array of tables
      * @return link to the inserted table inside the tree
      */
-    @Suppress("TOO_LONG_FUNCTION")
+    @Suppress("UNUSED_PARAMETER")
     public fun insertTableToTree(tomlTable: TomlTable, latestCreatedBucket: TomlArrayOfTablesElement? = null): TomlNode {
-        // important to save and update parental node
-        var previousParent = this
-        // going through parts of the table to create new tables in the tree in case some fragments are missing
-        tomlTable.tablesList.forEachIndexed { level, subTable ->
-            val foundTable = previousParent.findTableInAstByName(subTable)
-            // flag that will be used to check if we need to create a copy of the table in the tree or not
-            var constructNewBucket = false
-            // if the part of the table was found and it is inside the array - we need to determine if we need to create a copy or not
-            if (foundTable != null && foundTable.parent is TomlArrayOfTablesElement) {
-                val freeBucket = (foundTable.parent?.parent as TomlTable).children.last()
-                // need to create a new array of tables in the tree only
-                // if there was an array before:
-                // [[a]]                                                                      [[a]]
-                // [[a.b]]   in case of the nested array we should not create a copy:      [[a.b]]
-                // [[a]]                                                                       [[a.b]]
-                // [[a.b]]                                                                 [[a.b]]
-                if (tomlTable.type == TableType.PRIMITIVE || freeBucket == latestCreatedBucket) {
-                    previousParent = freeBucket
-                    constructNewBucket = true
-                }
-            }
+        var previousParent: TomlNode = this
 
-            previousParent = if (foundTable != null && !constructNewBucket) {
-                // in case of inline tables we generate a structure that already has key-values inserted to it,
-                // so we need to copy these children to the TOML AST
-                if (level == tomlTable.tablesList.lastIndex) {
-                    tomlTable.children.forEach {
-                        foundTable.appendChild(it)
-                    }
+        tomlTable.tablesList.forEachIndexed { level, subTable ->
+            val isLastLevel = level == tomlTable.tablesList.lastIndex
+            val foundTable = previousParent.findTableInAstByName(subTable)
+
+            previousParent = when {
+                foundTable != null && isLastLevel && foundTable.type == tomlTable.type -> {
+                    tomlTable.children.forEach(foundTable::appendChild)
+                    foundTable
                 }
-                foundTable
-            } else {
-                if (level == tomlTable.tablesList.lastIndex) {
+
+                foundTable != null -> foundTable.resolveInsertionParent()
+
+                isLastLevel -> {
                     previousParent.determineParentAndInsertFragmentOfTable(tomlTable)
                     tomlTable
-                } else {
-                    // creating a synthetic (technical) fragment of the table
+                }
+
+                else -> {
                     val newChildTableName = TomlTable(
                         TomlKey(subTable, lineNo),
                         lineNo,
-                        tomlTable.type,
+                        TableType.PRIMITIVE,
                         tomlTable.comments,
                         tomlTable.inlineComment,
                         isSynthetic = true
@@ -223,6 +206,13 @@ public sealed class TomlNode(
             this.appendChild(childTable)
         }
     }
+
+    private fun TomlTable.resolveInsertionParent(): TomlNode =
+        if (type == TableType.ARRAY) {
+            children.lastOrNull() as? TomlArrayOfTablesElement ?: this
+        } else {
+            this
+        }
 
     /**
      * Writes this node as text to [emitter].

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/keys/TomlKey.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/keys/TomlKey.kt
@@ -2,8 +2,8 @@ package com.akuleshov7.ktoml.tree.nodes.pairs.keys
 
 import com.akuleshov7.ktoml.TomlOutputConfig
 import com.akuleshov7.ktoml.exceptions.TomlWritingException
+import com.akuleshov7.ktoml.parsers.parseKeyName
 import com.akuleshov7.ktoml.parsers.splitKeyToTokens
-import com.akuleshov7.ktoml.parsers.trimAllQuotes
 import com.akuleshov7.ktoml.writers.TomlEmitter
 import com.akuleshov7.ktoml.writers.TomlStringEmitter
 
@@ -31,10 +31,10 @@ public class TomlKey internal constructor(
     ) : this(rawContent.splitKeyToTokens(lineNo))
 
     /**
-     * Gets the last key part, with all whitespace and quotes trimmed, i.e. `c` in
-     * `a.b.' c '`
+     * Gets the last key part in AST form, with quotes removed and escapes resolved
+     * for basic keys.
      */
-    public fun last(): String = keyParts.last().trimAllQuotes().trim()
+    public fun last(): String = keyParts.last().parseKeyName(lineNo = 0)
 
     public fun write(emitter: TomlEmitter) {
         val keys = keyParts

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/tables/TomlTable.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/tables/TomlTable.kt
@@ -6,8 +6,8 @@ package com.akuleshov7.ktoml.tree.nodes
 
 import com.akuleshov7.ktoml.TomlOutputConfig
 import com.akuleshov7.ktoml.exceptions.ParseException
+import com.akuleshov7.ktoml.parsers.parseKeyName
 import com.akuleshov7.ktoml.parsers.takeBeforeComment
-import com.akuleshov7.ktoml.parsers.trimAllQuotes
 import com.akuleshov7.ktoml.parsers.trimBrackets
 import com.akuleshov7.ktoml.parsers.trimDoubleBrackets
 import com.akuleshov7.ktoml.tree.nodes.pairs.keys.TomlKey
@@ -43,7 +43,7 @@ public class TomlTable(
     public var tablesList: List<String> = fullTableKey.keyParts.runningReduce { prev, cur -> "$prev.$cur" }
 
     // short table name (only the name without parental prefix, like a - it is used in decoder and encoder)
-    public override val name: String = fullTableKey.keyParts.last().trimAllQuotes()
+    public override val name: String = fullTableKey.keyParts.last().parseKeyName(lineNo)
 
     public constructor(
         content: String,

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/tables/TomlTable.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/tables/TomlTable.kt
@@ -7,9 +7,9 @@ package com.akuleshov7.ktoml.tree.nodes
 import com.akuleshov7.ktoml.TomlOutputConfig
 import com.akuleshov7.ktoml.exceptions.ParseException
 import com.akuleshov7.ktoml.parsers.takeBeforeComment
+import com.akuleshov7.ktoml.parsers.trimAllQuotes
 import com.akuleshov7.ktoml.parsers.trimBrackets
 import com.akuleshov7.ktoml.parsers.trimDoubleBrackets
-import com.akuleshov7.ktoml.parsers.trimQuotes
 import com.akuleshov7.ktoml.tree.nodes.pairs.keys.TomlKey
 import com.akuleshov7.ktoml.writers.TomlEmitter
 import com.akuleshov7.ktoml.writers.TomlStringEmitter
@@ -43,7 +43,7 @@ public class TomlTable(
     public var tablesList: List<String> = fullTableKey.keyParts.runningReduce { prev, cur -> "$prev.$cur" }
 
     // short table name (only the name without parental prefix, like a - it is used in decoder and encoder)
-    public override val name: String = fullTableKey.keyParts.last().trimQuotes()
+    public override val name: String = fullTableKey.keyParts.last().trimAllQuotes()
 
     public constructor(
         content: String,

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/parsers/ArraysOfTablesTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/parsers/ArraysOfTablesTest.kt
@@ -97,7 +97,7 @@ class ArraysOfTablesTest {
         assertEquals(
             """
                 | - TomlFile (rootNode)
-                |     - TomlTable ([[fruits]])
+                |     - TomlTable ([fruits])
                 |         - TomlTable ([[fruits.varieties]])
                 |             - TomlArrayOfTablesElement (technical_node)
                 |                 - TomlKeyValuePrimitive (name="red delicious")
@@ -126,7 +126,7 @@ class ArraysOfTablesTest {
         assertEquals(
             """
                 | - TomlFile (rootNode)
-                |     - TomlTable ([[fruits]])
+                |     - TomlTable ([fruits])
                 |         - TomlTable ([[fruits.varieties]])
                 |             - TomlArrayOfTablesElement (technical_node)
                 |                 - TomlKeyValuePrimitive (name="red delicious")
@@ -285,7 +285,6 @@ class ArraysOfTablesTest {
                     |             - TomlTable ([fruits.physical])
                     |                 - TomlKeyValuePrimitive (color="red")
                     |                 - TomlKeyValuePrimitive (shape="round")
-                    |             - TomlTable ([fruits.physical])
                     |                 - TomlTable ([fruits.physical.inside])
                     |                     - TomlKeyValuePrimitive (color="red")
                     |                     - TomlKeyValuePrimitive (shape="round")
@@ -396,15 +395,15 @@ class ArraysOfTablesTest {
         assertEquals(
             """
                         | - TomlFile (rootNode)
-                        |     - TomlTable ([[a]])
+                        |     - TomlTable ([a])
                         |         - TomlTable ([[a.b]])
                         |             - TomlArrayOfTablesElement (technical_node)
                         |                 - TomlTable ([[a.b.c]])
                         |                     - TomlArrayOfTablesElement (technical_node)
                         |                     - TomlArrayOfTablesElement (technical_node)
                         |                         - TomlKeyValuePrimitive (a=1)
-                        |                         - TomlTable ([[a.b.c.d]])
-                        |                             - TomlTable ([[a.b.c.d.e]])
+                        |                         - TomlTable ([a.b.c.d])
+                        |                             - TomlTable ([a.b.c.d.e])
                         |                                 - TomlTable ([[a.b.c.d.e.f]])
                         |                                     - TomlArrayOfTablesElement (technical_node)
                         |             - TomlArrayOfTablesElement (technical_node)
@@ -515,7 +514,7 @@ class ArraysOfTablesTest {
         assertEquals(
             """
                 | - TomlFile (rootNode)
-                |     - TomlTable ([[a]])
+                |     - TomlTable ([a])
                 |         - TomlTable ([[a.b]])
                 |             - TomlArrayOfTablesElement (technical_node)
                 |                 - TomlKeyValuePrimitive (name=1)
@@ -555,7 +554,7 @@ class ArraysOfTablesTest {
                 | - TomlFile (rootNode)
                 |     - TomlTable ([a])
                 |         - TomlKeyValuePrimitive (name=1)
-                |         - TomlTable ([[a.b]])
+                |         - TomlTable ([a.b])
                 |             - TomlTable ([[a.b.c]])
                 |                 - TomlArrayOfTablesElement (technical_node)
                 |                     - TomlKeyValuePrimitive (name=2)
@@ -636,7 +635,6 @@ class ArraysOfTablesTest {
                 |             - TomlKeyValuePrimitive (simple=5)
                 |             - TomlTable ([table.item])
                 |                 - TomlKeyValuePrimitive (simple=6)
-                |             - TomlTable ([table.item])
                 |                 - TomlTable ([table.item.complex])
                 |                     - TomlKeyValuePrimitive (a=7)
                 |                     - TomlKeyValuePrimitive (b=8)

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/parsers/DottedKeyParserTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/parsers/DottedKeyParserTest.kt
@@ -27,7 +27,11 @@ class DottedKeyParserTest {
         assertEquals(true, test.isDotted)
 
         test = TomlKey("\"  a  \"", 0)
-        assertEquals("a", test.last())
+        assertEquals("  a  ", test.last())
+        assertEquals(false, test.isDotted)
+
+        test = TomlKey("\"\\ttab\\ttab\\t\"", 0)
+        assertEquals("\ttab\ttab\t", test.last())
         assertEquals(false, test.isDotted)
 
         test = TomlKey("a.b.c", 0)
@@ -35,7 +39,7 @@ class DottedKeyParserTest {
         assertEquals(true, test.isDotted)
 
         test = TomlKey("a.\"  b  .c \"", 0)
-        assertEquals("b  .c", test.last())
+        assertEquals("  b  .c ", test.last())
         assertEquals(true, test.isDotted)
 
         test = TomlKey("a  .  b .  c ", 0)

--- a/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
+++ b/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
@@ -14,7 +14,6 @@ package com.akuleshov7.ktoml.compliance
  * | Datetime offset normalized to UTC | [#375](https://github.com/orchestr7/ktoml/issues/375) |
  * | Float representation lost | [#376](https://github.com/orchestr7/ktoml/issues/376) |
  * | Dotted key expansion incorrect | [#377](https://github.com/orchestr7/ktoml/issues/377) |
- * | Key names not unquoted | [#379](https://github.com/orchestr7/ktoml/issues/379) |
  * | Parser rejects valid TOML | [#380](https://github.com/orchestr7/ktoml/issues/380) |
  * | Stack overflow on deep nesting | [#381](https://github.com/orchestr7/ktoml/issues/381) |
  * | Multiline string escape handling | [#382](https://github.com/orchestr7/ktoml/issues/382) |
@@ -67,18 +66,6 @@ data object DottedKeyExpansion : KnownFailure {
         "valid/key/dotted-04.toml",
         "valid/key/dotted-empty.toml",
         "valid/key/quoted-dots.toml",
-    )
-}
-
-/** Key names retain quote characters in AST name property */
-data object KeyNameQuoting : KnownFailure {
-    override val issue = 379
-    override val tests = listOf(
-        "valid/key/space.toml",
-        "valid/multibyte.toml",
-        "valid/table/empty-name.toml",
-        "valid/table/with-literal-string.toml",
-        "valid/table/with-single-quotes.toml",
     )
 }
 
@@ -392,7 +379,6 @@ val allKnownFailures: List<KnownFailure> = listOf(
     DatetimeOffsetLoss,
     FloatRepresentationLoss,
     DottedKeyExpansion,
-    KeyNameQuoting,
     ValidTomlRejected,
     StackOverflowOnNesting,
     MultilineStringEscape,

--- a/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
+++ b/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
@@ -57,15 +57,9 @@ data object FloatRepresentationLoss : KnownFailure {
 data object DottedKeyExpansion : KnownFailure {
     override val issue = 377
     override val tests = listOf(
-        "valid/inline-table/key-dotted-01.toml",
+        // most dotted-key cases are fixed by the table-tree change; these two still fail
         "valid/inline-table/key-dotted-02.toml",
-        "valid/inline-table/key-dotted-04.toml",
         "valid/inline-table/key-dotted-06.toml",
-        "valid/key/dotted-01.toml",
-        "valid/key/dotted-02.toml",
-        "valid/key/dotted-04.toml",
-        "valid/key/dotted-empty.toml",
-        "valid/key/quoted-dots.toml",
     )
 }
 
@@ -356,7 +350,6 @@ data object TomlOneOneValidFeatures : KnownFailure {
         "valid/spec-1.1.0/common-27.toml",
         "valid/spec-1.1.0/common-29.toml",
         "valid/spec-1.1.0/common-35.toml",
-        "valid/spec-1.1.0/common-40.toml",
         "valid/spec-1.1.0/common-47.toml",
     )
 }

--- a/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
+++ b/ktoml-core/src/jvmTest/kotlin/com/akuleshov7/ktoml/compliance/TomlTestBaseline.kt
@@ -14,7 +14,6 @@ package com.akuleshov7.ktoml.compliance
  * | Datetime offset normalized to UTC | [#375](https://github.com/orchestr7/ktoml/issues/375) |
  * | Float representation lost | [#376](https://github.com/orchestr7/ktoml/issues/376) |
  * | Dotted key expansion incorrect | [#377](https://github.com/orchestr7/ktoml/issues/377) |
- * | Array-of-tables structure | [#378](https://github.com/orchestr7/ktoml/issues/378) |
  * | Key names not unquoted | [#379](https://github.com/orchestr7/ktoml/issues/379) |
  * | Parser rejects valid TOML | [#380](https://github.com/orchestr7/ktoml/issues/380) |
  * | Stack overflow on deep nesting | [#381](https://github.com/orchestr7/ktoml/issues/381) |
@@ -68,18 +67,6 @@ data object DottedKeyExpansion : KnownFailure {
         "valid/key/dotted-04.toml",
         "valid/key/dotted-empty.toml",
         "valid/key/quoted-dots.toml",
-    )
-}
-
-/** Array-of-tables produces wrong AST structure in edge cases */
-data object ArrayOfTablesStructure : KnownFailure {
-    override val issue = 378
-    override val tests = listOf(
-        "valid/array/open-parent-table.toml",
-        "valid/table/array-empty-name.toml",
-        "valid/table/array-implicit.toml",
-        "valid/table/array-implicit-and-explicit-after.toml",
-        "valid/table/array-table-array.toml",
     )
 }
 
@@ -405,7 +392,6 @@ val allKnownFailures: List<KnownFailure> = listOf(
     DatetimeOffsetLoss,
     FloatRepresentationLoss,
     DottedKeyExpansion,
-    ArrayOfTablesStructure,
     KeyNameQuoting,
     ValidTomlRejected,
     StackOverflowOnNesting,


### PR DESCRIPTION
Fixes #378, #379, and #377.

These three are entangled at the AST level — the array-of-tables structure fix and the key/table-name unquoting fix touch the same table-tree code — so they ship as one change:

- **#378** — corrects array-of-tables AST structure in edge cases (table-tree insertion in `TomlNode`/`TomlTable`).
- **#379** — a `parseKeyName` helper strips quotes and applies escaping for key/table names; `TomlKey.last()`, `TomlTable.name`, and table lookup in `TomlNode` now go through it.
- **#377** — the same table-tree fix produces correct synthetic nested tables for the dotted-key cases it covers.

Compliance suite: removes the `ArrayOfTablesStructure` and `KeyNameQuoting` baseline entries plus the now-passing subset of `DottedKeyExpansion`; dotted cases that still fail remain baselined.
