### PR TITLE
fix: reject unicode escapes with invalid hex digits or out-of-range code points

### DIFF
--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/utils/SpecialCharacters.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/utils/SpecialCharacters.kt
@@ -17,6 +17,7 @@ internal const val COMPLEX_UNICODE_PREFIX = 'U'
 internal const val BIN_RADIX = 2
 internal const val OCT_RADIX = 8
 internal const val HEX_RADIX = 16
+internal const val MAX_CODE_POINT = 0x10_FF_FF
 internal const val SIMPLE_UNICODE_LENGTH = 4
 internal const val SIMPLE_UNICODE_PREFIX = 'u'
 
@@ -87,12 +88,15 @@ public fun StringBuilder.appendEscapedUnicode(
         throw UnknownEscapeSymbolsException("\\$invalid", lineNo)
     }
     val hexCode = fullString.substring(codeStartIndex, codeStartIndex + nbUnicodeChars)
-    val codePoint = hexCode.toInt(HEX_RADIX)
-    try {
-        appendCodePointCompat(codePoint)
-    } catch (e: IllegalArgumentException) {
-        throw UnknownEscapeSymbolsException("\\$marker$hexCode", lineNo)
-    }
+    // toLong rather than toInt because eight hex digits overflow an Int, and the digits are
+    // checked one by one first because both parsers accept a leading sign: "+041" would
+    // otherwise be read as U+0041 instead of being rejected
+    val codePoint = hexCode
+        .takeIf { code -> code.all { it.digitToIntOrNull(HEX_RADIX) != null } }
+        ?.toLong(HEX_RADIX)
+        ?.takeIf { it <= MAX_CODE_POINT }
+        ?: throw UnknownEscapeSymbolsException("\\$marker$hexCode", lineNo)
+    appendCodePointCompat(codePoint.toInt())
     return nbUnicodeChars
 }
 

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/parsers/ValueParserTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/parsers/ValueParserTest.kt
@@ -129,16 +129,16 @@ class ValueParserTest {
             )
         }
         assertFailsWith<ParseException> {
-            TomlKeyValuePrimitive("a" to "val\\ue", 0)
+            TomlKeyValuePrimitive("a" to "\"val\\ue\"", 0)
         }
         assertFailsWith<ParseException> {
-            TomlKeyValuePrimitive("a" to "\\x33", 0)
+            TomlKeyValuePrimitive("a" to "\"\\x33\"", 0)
         }
         assertFailsWith<ParseException> {
-            TomlKeyValuePrimitive("a" to "\\UFFFFFFFF", 0)
+            TomlKeyValuePrimitive("a" to "\"\\UFFFFFFFF\"", 0)
         }
         assertFailsWith<ParseException> {
-            TomlKeyValuePrimitive("a" to "\\U00D80000", 0)
+            TomlKeyValuePrimitive("a" to "\"\\U00D80000\"", 0)
         }
     }
 }

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/utils/SpecialCharactersTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/utils/SpecialCharactersTest.kt
@@ -1,0 +1,58 @@
+package com.akuleshov7.ktoml.utils
+
+import com.akuleshov7.ktoml.Toml
+import com.akuleshov7.ktoml.exceptions.ParseException
+import com.akuleshov7.ktoml.exceptions.UnknownEscapeSymbolsException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class SpecialCharactersTest {
+    @Serializable
+    data class SimpleString(val a: String)
+
+    @Test
+    fun testValidUnicodeEscapesAreConverted() {
+        assertEquals("A", "\\u0041".convertSpecialCharacters(1))
+        assertEquals("\uD83D\uDCA9", "\\U0001F4A9".convertSpecialCharacters(1))
+        assertEquals("\u00FF", "\\u00ff".convertSpecialCharacters(1))
+    }
+
+    @Test
+    fun testMalformedUnicodeEscapesAreRejected() {
+        val malformed = listOf(
+            "\\uZZZZ",
+            // a single non-hex digit in an otherwise well-formed code
+            "\\uabag",
+            // both toInt and toLong accept a leading sign, which would smuggle these
+            // through as U+0041
+            "\\u+041",
+            "\\u-041",
+            // eight hex digits overflow an Int
+            "\\UFFFFFFFF",
+            // parses cleanly but sits above the highest code point
+            "\\U0011FFFF",
+            "\\U00D80000",
+            // the code is cut short by the end of the string
+            "\\u041",
+        )
+
+        malformed.forEach { input ->
+            assertFailsWith<UnknownEscapeSymbolsException>("expected <$input> to be rejected") {
+                input.convertSpecialCharacters(1)
+            }
+        }
+    }
+
+    @Test
+    fun testMalformedUnicodeEscapeInDecodedTomlRaisesParseException() {
+        assertFailsWith<ParseException> {
+            Toml.decodeFromString<SimpleString>("a = \"\\uZZZZ\"")
+        }
+        assertFailsWith<ParseException> {
+            Toml.decodeFromString<SimpleString>("a = \"\\u+041\"")
+        }
+    }
+}


### PR DESCRIPTION
Hi! We're developing [SnaKt, a Kotlin formal verification tool](https://github.com/JetBrains/SnaKt) and decided to try it out on this project.  This lead to us finding this minor bug, as well as [an even smaller issue](https://github.com/jesyspa/ktoml/commit/2b4bd41bba6c11f50bf1ce6680f604c7083ba6bd).

We'd be happy to keep testing our tool on the project and sending you issue reports/bug fixes as they come up, but I'm not sure if they're worth your review time.  Please let me know what you'd prefer.  The code is AI-generated, in case that matters.

The issue: the unicode escape parser checks how long an escape is but never what it contains, so it accepts some invalid TOML outright. `"\u+041"` decodes to `"A"`, because `toInt(HEX_RADIX)` tolerates a leading sign. It reports other invalid escapes with a raw `NumberFormatException`, which sits outside `TomlDecodingException`, so callers catching `SerializationException` never see it. Non-hex digits (`"\uZZZZ"`) and eight digits that overflow an `Int` (`"\UFFFFFFFF"`) both land there.

This PR validates each digit and range-checks the code point as a `Long`. `appendCodePointCompat` can no longer receive an invalid value, so I removed the now-dead `try`/`catch` around it.

Four assertions in `ValueParserTest.parsingIssueValue` passed unquoted values to `TomlKeyValuePrimitive`, so they never reached escape handling at all. One of them covered the `\UFFFFFFFF` overflow above.

Refs #383.

